### PR TITLE
Fix package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "bitclout-frontend",
   "version": "0.0.0",
   "scripts": {
-    "ng": "./node_modules/.bin/ng",
-    "start": "./node_modules/.bin/ng serve",
-    "build": "./node_modules/.bin/ng build",
-    "test": "./node_modules/.bin/ng test",
-    "lint": "./node_modules/.bin/ng lint",
-    "e2e": "./node_modules/.bin/ng e2e",
-    "build_prod": "./node_modules/.bin/ng build --prod --base-href / --deploy-url /",
-    "ngcc": "./node_modules/.bin/ngcc --properties es2015"
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "test": "ng test",
+    "lint": "ng lint",
+    "e2e": "ng e2e",
+    "build_prod": "ng build --prod --base-href / --deploy-url /",
+    "ngcc": "ngcc --properties es2015"
   },
   "browserslist": [
     "> 5%"


### PR DESCRIPTION
No need to specify the bins directly in the script configs can just list them directly. This ensures that both they are portable to all systems (windows/mac/linux) but also more flexible. More info here: https://docs.npmjs.com/cli/v7/using-npm/scripts#path