### PR TITLE
fix: prevent long words (such as urls) from making message pill overflow

### DIFF
--- a/src/app/messages-page/message/message.component.html
+++ b/src/app/messages-page/message/message.component.html
@@ -3,11 +3,12 @@
 <!--                                         -->
 <div *ngIf="message.IsSender" class="d-flex justify-content-end align-items-end">
   <!--"Pre-wrap" allows us to render new lines properly-->
+  <!--"overflow-wrap" prevents long words from overflowing messages container (such as URLs)-->
   <!-- The messages are received from the backend encrypted. If we have the unencrypted
        text stored we use that instead. -->
   <div
     class="d-flex align-items-center py-5px px-15px messages-thread__border-radius fs-15px message__min-height message__sender-bubble-color"
-    style="white-space: pre-wrap"
+    style="white-space: pre-wrap; overflow-wrap: anywhere"
   >
     {{
       globalVars.messageMeta.decryptedMessgesMap[


### PR DESCRIPTION
See screenshot for an example of current behavior this PR fixes:

<img src="https://user-images.githubusercontent.com/4400527/117017738-bf32c680-aceb-11eb-9650-f3194fd42c46.png" width="400">

