### PR TITLE
Updated CC Transfer message

### DIFF
--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -1319,7 +1319,7 @@ export class BackendApiService {
       } else if (errorMessage.indexOf("RuleErrorInputSpendsPreviouslySpentOutput") >= 0) {
         errorMessage = "You're doing that a bit too quickly. Please wait a second or two and try again.";
       } else if (errorMessage.indexOf("RuleErrorCreatorCoinTransferBalanceEntryDoesNotExist") >= 0) {
-        errorMessage = "You must own this creator coin before transfering it.";
+        errorMessage = "You must own this creator coin before transferring it.";
       }
   }
     return errorMessage;

--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -1319,7 +1319,7 @@ export class BackendApiService {
       } else if (errorMessage.indexOf("RuleErrorInputSpendsPreviouslySpentOutput") >= 0) {
         errorMessage = "You're doing that a bit too quickly. Please wait a second or two and try again.";
       } else if (errorMessage.indexOf("RuleErrorCreatorCoinTransferBalanceEntryDoesNotExist") >= 0) {
-        errorMessage = "You need to buy some of your creator coin before you can give a diamond.";
+        errorMessage = "You must own this creator coin before transfering it.";
       }
   }
     return errorMessage;


### PR DESCRIPTION
Since the `RuleErrorCreatorCoinTransferBalanceEntryDoesNotExist` error does not only occur when diamonds are being sent, I think that a more appropriate error message would be one that covers all scenarios which cause the error to occur.

While sending diamonds without holding your own coin is the most common of these scenarios, this error will also occur if you transfer a creator coin, receive a rate-limiting error, and try again. This is because sometimes the request still gets processed, even following a rate limit error, thus the frontend will still show you hold a creator coin even when your initial request was sent already. Getting an error regarding diamonds in this scenario is fairly confusing, and thus should be clarified.

Since a diamond is just a button to quickly transfer creator coins (Along with some extra metadata in the transfer tx), an error that does not specify diamonds but rather mentions transfers (Since transfers are what the error is for) makes the most sense here.

Error reference:
```json
{"error":": SubmitTransaction: Problem processing transaction: _augmentAndProcessTransaction: Problem validating txn: ValidateTransaction: Problem validating transaction: : ConnectTransaction: : RuleErrorCreatorCoinTransferBalanceEntryDoesNotExist"}
```