### PR TITLE
fix unread box when >100 unread messages

### DIFF
--- a/src/app/bottom-bar-mobile/bottom-bar-mobile.component.html
+++ b/src/app/bottom-bar-mobile/bottom-bar-mobile.component.html
@@ -34,7 +34,7 @@
           *ngIf="globalVars.messageNotificationCount > 0"
           class="bottom-bar__message-notifications-bubble roboto-mono"
         >
-        {{ globalVars.messageNotificationCount > 999 ? "loads" : globalVars.messageNotificationCount }}
+        {{ globalVars.messageNotificationCount > 999 ? "999+" : globalVars.messageNotificationCount }}
         </div>
       </i>
     </bottom-bar-mobile-tab>

--- a/src/app/bottom-bar-mobile/bottom-bar-mobile.component.html
+++ b/src/app/bottom-bar-mobile/bottom-bar-mobile.component.html
@@ -34,7 +34,7 @@
           *ngIf="globalVars.messageNotificationCount > 0"
           class="bottom-bar__message-notifications-bubble roboto-mono"
         >
-          {{ globalVars.messageNotificationCount }}
+        {{ globalVars.messageNotificationCount > 999 ? "loads" : globalVars.messageNotificationCount }}
         </div>
       </i>
     </bottom-bar-mobile-tab>

--- a/src/app/left-bar/left-bar-button/left-bar-button.component.html
+++ b/src/app/left-bar/left-bar-button/left-bar-button.component.html
@@ -41,7 +41,7 @@
         text-align: center;
         line-height: 18px;
         height: 20px;
-        width: 20px;
+        padding: 0px 5px;
       "
     >
       {{ globalVars.messageNotificationCount }}

--- a/src/app/left-bar/left-bar-button/left-bar-button.component.html
+++ b/src/app/left-bar/left-bar-button/left-bar-button.component.html
@@ -44,7 +44,7 @@
         padding: 0px 5px;
       "
     >
-      {{ globalVars.messageNotificationCount > 999 ? "loads" : globalVars.messageNotificationCount }}
+      {{ globalVars.messageNotificationCount > 999 ? "999+" : globalVars.messageNotificationCount }}
     </div>
   </div>
 </div>

--- a/src/app/left-bar/left-bar-button/left-bar-button.component.html
+++ b/src/app/left-bar/left-bar-button/left-bar-button.component.html
@@ -44,7 +44,7 @@
         padding: 0px 5px;
       "
     >
-      {{ globalVars.messageNotificationCount }}
+      {{ globalVars.messageNotificationCount > 999 ? "loads" : globalVars.messageNotificationCount }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
I noticed this when re-syncing my node.

![formatting-issue](https://user-images.githubusercontent.com/69529928/117298045-d0f0a700-ae6e-11eb-98b3-c04b6be11a71.png)

This PR removes the width and adds some padding to fix this.

![fix-100+](https://user-images.githubusercontent.com/69529928/117298157-f2ea2980-ae6e-11eb-913c-955a06654dea.png)


Also still ok with smaller unread messages.

![20210506-ypo9yNCH](https://user-images.githubusercontent.com/69529928/117298168-f54c8380-ae6e-11eb-8bb2-41b3d760bc94.png)

Small change but hopefully useful.
