### PR TITLE
add button to mark all messages as read

### DIFF
--- a/src/app/messages-page/messages-inbox/messages-inbox.component.html
+++ b/src/app/messages-page/messages-inbox/messages-inbox.component.html
@@ -1,9 +1,10 @@
 <!-- Top Bar -->
-<div
-  *ngIf="!isMobile"
-  class="w-100 global__top-bar__height d-flex align-items-center pl-15px fs-18px font-weight-bold border-bottom border-color-grey"
->
+<div *ngIf="!isMobile" class="w-100 global__top-bar__height d-flex align-items-center pl-15px fs-18px font-weight-bold border-bottom border-color-grey">
   Messages
+    <div class="d-flex justify-content-end w-100 align-items-right pr-15px pb-15px mt-10px">
+        <i *ngIf="hasUnreadMessages" (click)="_markAllUnread()" class="fc-blue icon-messages cursor-pointer feed-post-icon-row__icon"></i>
+        <i *ngIf="!hasUnreadMessages" class="fc-light icon-messages" style="color:#ccc; font-size: 25px;border-radius: 50%;margin-right: 2px;"></i>
+    </div>
 </div>
 
 <search-bar

--- a/src/app/messages-page/messages-inbox/messages-inbox.component.ts
+++ b/src/app/messages-page/messages-inbox/messages-inbox.component.ts
@@ -18,6 +18,7 @@ export class MessagesInboxComponent implements OnInit, OnChanges {
   @Input() isMobile = false;
   @Output() selectedThreadEmitter = new EventEmitter<any>();
   selectedThread: any;
+  hasUnreadMessages: boolean;
 
   // The contact to select by default, passed in via query param. Note: if the current user
   // doesn't have a conversation with the contact, these parameters do nothing.
@@ -40,7 +41,7 @@ export class MessagesInboxComponent implements OnInit, OnChanges {
     if (this.messageThreads && this.messageThreads.length > 0) {
       this.updateReadMessagesForSelectedThread();
     }
-
+    this.hasUnreadMessages = (this.globalVars.messageNotificationCount != 0)
     this._setSelectedThreadBasedOnDefaultThread();
   }
 
@@ -48,6 +49,7 @@ export class MessagesInboxComponent implements OnInit, OnChanges {
     // If messageThreads were not loaded when the component initialized, we handle them here.
     if (changes.messageThreads.previousValue === null && changes.messageThreads.currentValue.length > 0) {
       this.updateReadMessagesForSelectedThread();
+      this.hasUnreadMessages = (this.globalVars.messageNotificationCount != 0)
     }
   }
 
@@ -158,4 +160,24 @@ export class MessagesInboxComponent implements OnInit, OnChanges {
         }
       );
   }
+
+  _markAllUnread() {
+    this.hasUnreadMessages=false
+    const messageReadStateUpdatesByContact = this.globalVars.messageResponse.TotalMessagesByContact
+    this.globalVars.messageResponse.MessageReadStateByContact = this.globalVars.messageResponse.TotalMessagesByContact
+    this.globalVars._setNumMessagesToRead();
+    this.backendApi.UpdateUserGlobalMetadata(
+      this.globalVars.localNode,
+      this.globalVars.loggedInUser.PublicKeyBase58Check /*UpdaterPublicKeyBase58Check*/,
+      "" /*EmailAddress*/,
+      messageReadStateUpdatesByContact
+    )
+    .subscribe(
+      (res) => {},
+      (err) => {
+        console.log(err);
+      }
+    );
+  }
+
 }


### PR DESCRIPTION
Another issue I ran into using my own node - messages show up as unread and there was no easy way to mark them all as read.

![fix-100+](https://user-images.githubusercontent.com/69529928/117298924-d8fd1680-ae6f-11eb-9189-91b021c58c0c.png)

So added a button. Im not familiar with ts/angular so im sure several mistakes made and improvements possible. 

Would be good if someone with better knowledge & experience could chip in with improvements?

When you have unread messages - the button is active like this:

![unread-messages-button-active](https://user-images.githubusercontent.com/69529928/117306177-5d06cc80-ae77-11eb-8434-e8b3245688e6.png)

When all are read, or button is pressed, it is inactive and gray.

![all-read-inactive-button](https://user-images.githubusercontent.com/69529928/117306212-66903480-ae77-11eb-9b68-0a681ea71bd5.png)

I dont really like the icon but I could not figure out how to reliably add a suitable read/unread icon from fontello as adding to CSS did not seem enough.