### PR TITLE
Ln/distinguish between purchases and transfers

### DIFF
--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -181,6 +181,8 @@ export class BalanceEntryResponse {
   // The public keys are provided for the frontend
   CreatorPublicKeyBase58Check: string;
 
+  // Has the hodler purchased these creator coins
+  HasPurchased: boolean;
   // How much this HODLer owns of a particular creator coin.
   BalanceNanos: number;
   // The net effect of transactions in the mempool on a given BalanceEntry's BalanceNanos.

--- a/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.html
+++ b/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.html
@@ -14,7 +14,7 @@
 
   <!-- Feed Selector -->
   <tab-selector
-    [tabs]="['Posts', 'Creator Coin', 'Diamonds']"
+    [tabs]="['Posts', 'Coin Purchasers', 'Diamonds']"
     [activeTab]="activeTab"
     (tabClick)="_handleTabClick($event)"
   ></tab-selector>
@@ -82,10 +82,10 @@
   </div>
 
   <!-- Creator Coin Info -->
-  <div class="w-100 d-flex flex-column" *ngIf="activeTab == 'Creator Coin' && !loading">
+  <div class="w-100 d-flex flex-column" *ngIf="activeTab == 'Coin Purchasers' && !loading">
     <div class="w-100 d-flex justify-content-start px-15px fs-15px">
       <div class="container border-bottom border-color-grey font-weight-bold fs-20px pl-0px py-15px">
-        Holders of ${{ profile.Username }} coin
+        Purchasers of ${{ profile.Username }} coin
       </div>
     </div>
 

--- a/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.ts
+++ b/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.ts
@@ -16,12 +16,14 @@ export class CreatorProfileDetailsComponent {
 
   static TABS = {
     posts: "Posts",
-    "creator-coin": "Creator Coin",
+    // Leaving this one in so old links will direct to the Coin Purchasers tab.
+    "creator-coin": "Coin Purchasers",
+    "coin-purchasers": "Coin Purchasers",
     diamonds: "Diamonds",
   };
   static TABS_LOOKUP = {
     Posts: "posts",
-    "Creator Coin": "creator-coin",
+    "Coin Purchasers": "coin-purchasers",
     Diamonds: "diamonds",
   };
   appData: GlobalVarsService;

--- a/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.html
+++ b/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.html
@@ -6,7 +6,7 @@
 </div>
 <simple-center-loader *ngIf="datasource.adapter.isLoading && loadingFirstPage"></simple-center-loader>
 <div #uiScroll *uiScroll="let row of datasource">
-  <div class="row no-gutters p-10px border-bottom mb-0" *ngIf="!row.totalRow && row.HasPurchased">
+  <div class="row no-gutters p-10px border-bottom mb-0" *ngIf="!row.totalRow && (row.HasPurchased || isRowForCreator(row))">
     <div class="col-6 d-flex align-items-center mb-0">
       <div *ngIf="!row.ProfileEntryResponse" class="d-flex align-items-center">
         <div

--- a/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.html
+++ b/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.html
@@ -6,7 +6,7 @@
 </div>
 <simple-center-loader *ngIf="datasource.adapter.isLoading && loadingFirstPage"></simple-center-loader>
 <div #uiScroll *uiScroll="let row of datasource">
-  <div class="row no-gutters p-10px border-bottom mb-0" *ngIf="!row.totalRow">
+  <div class="row no-gutters p-10px border-bottom mb-0" *ngIf="!row.totalRow && row.HasPurchased">
     <div class="col-6 d-flex align-items-center mb-0">
       <div *ngIf="!row.ProfileEntryResponse" class="d-flex align-items-center">
         <div
@@ -38,13 +38,13 @@
   <div class="row no-gutters font-weight-bold" *ngIf="row.totalRow">
     <div class="col-6 py-15px mb-0">Total</div>
     <div class="col-3 py-15px mb-0">
-      {{ (profile.CoinEntry.CoinsInCirculationNanos / 1e9).toFixed(4) }}
+      {{ (totalCoinsPurchasedInCirculation / 1e9).toFixed(4) }}
     </div>
     <div class="col-3 py-15px mb-0">
       ≈
       {{
         globalVars.creatorCoinNanosToUSDNaive(
-          profile.CoinEntry.CoinsInCirculationNanos,
+          totalCoinsPurchasedInCirculation,
           profile.CoinPriceBitCloutNanos,
           true
         )

--- a/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.ts
+++ b/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.ts
@@ -12,6 +12,7 @@ import { Datasource, IDatasource, IAdapter } from "ngx-ui-scroll";
 })
 export class CreatorProfileHodlersComponent {
   showTotal = false;
+  totalCoinsPurchasedInCirculation = 0;
 
   @Input() profile: ProfileEntryResponse;
 
@@ -104,6 +105,11 @@ export class CreatorProfileHodlersComponent {
       .toPromise()
       .then((res) => {
         const balanceEntryResponses: any[] = res.Hodlers;
+        balanceEntryResponses.forEach((balanceEntryResponse: BalanceEntryResponse) => {
+          if (balanceEntryResponse.HasPurchased) {
+            this.totalCoinsPurchasedInCirculation += balanceEntryResponse.BalanceNanos;
+          }
+        });
         this.pagedKeys[page + 1] = res.LastPublicKeyBase58Check || "";
         if (
           balanceEntryResponses.length < CreatorProfileHodlersComponent.PAGE_SIZE ||
@@ -119,5 +125,9 @@ export class CreatorProfileHodlersComponent {
         this.loadingFirstPage = false;
         return balanceEntryResponses;
       });
+  }
+
+  getTotalCoinsInCirculation(): number {
+    return 0;
   }
 }

--- a/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.ts
+++ b/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.ts
@@ -127,7 +127,7 @@ export class CreatorProfileHodlersComponent {
       });
   }
 
-  getTotalCoinsInCirculation(): number {
-    return 0;
+  isRowForCreator(row: BalanceEntryResponse) {
+    return row.CreatorPublicKeyBase58Check == row.HODLerPublicKeyBase58Check;
   }
 }

--- a/src/app/wallet/wallet.component.html
+++ b/src/app/wallet/wallet.component.html
@@ -192,7 +192,8 @@
           </div>
           <div
             *ngIf="(showTransferredCoins ? usersYouReceived : usersYouPurchased).length == 0"
-            class="d-flex justify-content-center fs-15px fc-muted w-100 mt-30px"
+            class="d-flex justify-content-center fs-15px fc-muted w-100 mt-30px px-15px"
+            style="text-align: center"
           >
             {{emptyHodlerListMessage()}}
           </div>

--- a/src/app/wallet/wallet.component.html
+++ b/src/app/wallet/wallet.component.html
@@ -76,6 +76,13 @@
           </div>
         </div>
 
+        <!-- Tab Selector -->
+        <tab-selector
+          [tabs]="tabs"
+          [activeTab]="activeTab"
+          (tabClick)="_handleTabClick($event)"
+        ></tab-selector>
+
         <div class="fs-15px">
           <div
             class="row no-gutters d-flex align-items-center fc-muted border-bottom border-color-grey pl-15px py-15px"
@@ -94,7 +101,7 @@
             </div>
             <div class="col-lg-1 col-2 d-block mb-0"></div>
           </div>
-          <div *ngFor="let creator of usersYouHODL()">
+          <div *ngFor="let creator of (showTransferredCoins ? usersYouReceived : usersYouPurchased)">
             <!-- Screen out zero balances -->
             <div
               *ngIf="
@@ -184,10 +191,10 @@
             </div>
           </div>
           <div
-            *ngIf="globalVars.loggedInUser.UsersYouHODL.length == 0"
+            *ngIf="(showTransferredCoins ? usersYouReceived : usersYouPurchased).length == 0"
             class="d-flex justify-content-center fs-15px fc-muted w-100 mt-30px"
           >
-            You don't hold any creator coins yet.
+            {{emptyHodlerListMessage()}}
           </div>
         </div>
 

--- a/src/app/wallet/wallet.component.ts
+++ b/src/app/wallet/wallet.component.ts
@@ -49,23 +49,6 @@ export class WalletComponent implements OnInit {
     });
   }
 
-  // getHodlingsForActiveTab() {
-  //   return this.showTransferredCoins ? this.usersYouReceived : this.usersYouPurchased;
-  // }
-
-  // usersYouHODL() {
-  //   const creators = this.globalVars.loggedInUser.UsersYouHODL.filter(
-  //     (creator: BalanceEntryResponse) => creator.HasPurchased == !this.showTransferredCoins
-  //   );
-  //   creators.sort((a, b) => {
-  //     return (
-  //       this.globalVars.bitcloutNanosYouWouldGetIfYouSold(b.BalanceNanos, b.ProfileEntryResponse.CoinEntry) -
-  //       this.globalVars.bitcloutNanosYouWouldGetIfYouSold(a.BalanceNanos, a.ProfileEntryResponse.CoinEntry)
-  //     );
-  //   });
-  //   return creators;
-  // }
-
   totalValue() {
     let result = 0;
 
@@ -110,7 +93,7 @@ export class WalletComponent implements OnInit {
 
   emptyHodlerListMessage(): string {
     return this.showTransferredCoins
-      ? "You haven't received coins from any creators you don't already hold"
+      ? "You haven't received coins from any creators you don't already hold."
       : "You haven't purchased any creator coins yet.";
   }
 

--- a/src/app/wallet/wallet.component.ts
+++ b/src/app/wallet/wallet.component.ts
@@ -30,7 +30,11 @@ export class WalletComponent implements OnInit {
       if (balanceEntryResponse.NetBalanceInMempool != 0) {
         this.hasUnminedCreatorCoins = true;
       }
-      if (balanceEntryResponse.HasPurchased) {
+      // If you purchased the coin or the balance entry response if for your creator coin, show it in the purchased tab.
+      if (
+        balanceEntryResponse.HasPurchased ||
+        balanceEntryResponse.HODLerPublicKeyBase58Check === balanceEntryResponse.CreatorPublicKeyBase58Check
+      ) {
         this.usersYouPurchased.push(balanceEntryResponse);
       } else {
         this.usersYouReceived.push(balanceEntryResponse);

--- a/src/app/wallet/wallet.component.ts
+++ b/src/app/wallet/wallet.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from "@angular/core";
 import { GlobalVarsService } from "../global-vars.service";
 import { AppRoutingModule } from "../app-routing.module";
+import { BalanceEntryResponse } from "../backend-api.service";
 
 @Component({
   selector: "wallet",
@@ -10,29 +11,60 @@ export class WalletComponent implements OnInit {
   globalVars: GlobalVarsService;
   AppRoutingModule = AppRoutingModule;
   hasUnminedCreatorCoins: boolean;
+  showTransferredCoins: boolean = false;
+
+  usersYouReceived: BalanceEntryResponse[] = [];
+  usersYouPurchased: BalanceEntryResponse[] = [];
+
+  static coinsPurchasedTab: string = "Coins Purchased";
+  static coinsReceivedTab: string = "Coins Received";
+  tabs = [WalletComponent.coinsPurchasedTab, WalletComponent.coinsReceivedTab];
+  activeTab: string = WalletComponent.coinsPurchasedTab;
 
   constructor(private appData: GlobalVarsService) {
     this.globalVars = appData;
   }
 
   ngOnInit() {
-    for (let creator of this.usersYouHODL()) {
-      if (creator.NetBalanceInMempool != 0) {
+    this.globalVars.loggedInUser.UsersYouHODL.map((balanceEntryResponse: BalanceEntryResponse) => {
+      if (balanceEntryResponse.NetBalanceInMempool != 0) {
         this.hasUnminedCreatorCoins = true;
       }
-    }
+      if (balanceEntryResponse.HasPurchased) {
+        this.usersYouPurchased.push(balanceEntryResponse);
+      } else {
+        this.usersYouReceived.push(balanceEntryResponse);
+      }
+    });
+    this.sortHodlings(this.usersYouPurchased);
+    this.sortHodlings(this.usersYouReceived);
   }
 
-  usersYouHODL() {
-    const creators = this.globalVars.loggedInUser.UsersYouHODL;
-    creators.sort((a, b) => {
+  sortHodlings(hodlings: BalanceEntryResponse[]): void {
+    hodlings.sort((a: BalanceEntryResponse, b: BalanceEntryResponse) => {
       return (
         this.globalVars.bitcloutNanosYouWouldGetIfYouSold(b.BalanceNanos, b.ProfileEntryResponse.CoinEntry) -
         this.globalVars.bitcloutNanosYouWouldGetIfYouSold(a.BalanceNanos, a.ProfileEntryResponse.CoinEntry)
       );
     });
-    return creators;
   }
+
+  // getHodlingsForActiveTab() {
+  //   return this.showTransferredCoins ? this.usersYouReceived : this.usersYouPurchased;
+  // }
+
+  // usersYouHODL() {
+  //   const creators = this.globalVars.loggedInUser.UsersYouHODL.filter(
+  //     (creator: BalanceEntryResponse) => creator.HasPurchased == !this.showTransferredCoins
+  //   );
+  //   creators.sort((a, b) => {
+  //     return (
+  //       this.globalVars.bitcloutNanosYouWouldGetIfYouSold(b.BalanceNanos, b.ProfileEntryResponse.CoinEntry) -
+  //       this.globalVars.bitcloutNanosYouWouldGetIfYouSold(a.BalanceNanos, a.ProfileEntryResponse.CoinEntry)
+  //     );
+  //   });
+  //   return creators;
+  // }
 
   totalValue() {
     let result = 0;
@@ -74,5 +106,16 @@ export class WalletComponent implements OnInit {
 
   usernameTruncationLength(): number {
     return this.globalVars.isMobile() ? 14 : 20;
+  }
+
+  emptyHodlerListMessage(): string {
+    return this.showTransferredCoins
+      ? "You haven't received coins from any creators you don't already hold"
+      : "You haven't purchased any creator coins yet.";
+  }
+
+  _handleTabClick(tab: string) {
+    this.showTransferredCoins = tab === WalletComponent.coinsReceivedTab;
+    this.activeTab = tab;
   }
 }


### PR DESCRIPTION
Currently our UI does not distinguish between coins you purchased and coins you received via transfers. 

This PR updates the wallet and the coin purchasers tab (formerly Creator Coins tab on a creator's profile) as follows:

- Wallet has two tabs - `Coins Purchased` and `Coins Transferred`
1. Coins Purchased: this shows all creator coin holdings of creator that you have purchased any amount of creator coin. This will include any holdings received via a diamond or a creator coin transfer
2. Coins Transferred: this tab shows coins of creators that you have never purchased.  The holdings on this tab are coins you have received exclusively by Creator Coin Transfer transactions.
- Coin Purchasers tab only displays users who have purchased a creator's coin.  The total row reflects the amount of coins held by the users who have purchased a creator's coin.