### PR TITLE
Creator Coin Significant Figures Rationalization

### DIFF
--- a/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.html
+++ b/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.html
@@ -28,7 +28,7 @@
       </a>
     </div>
     <div class="col-3 d-flex align-items-center mb-0">
-      {{ (row.BalanceNanos / 1e9).toFixed(4) }}
+      {{ (row.BalanceNanos / 1e9).toFixed(9) }}
     </div>
     <div class="col-3 d-flex align-items-center mb-0">
       ≈ {{ globalVars.creatorCoinNanosToUSDNaive(row.BalanceNanos, profile.CoinPriceBitCloutNanos, true) }}

--- a/src/app/wallet/wallet.component.html
+++ b/src/app/wallet/wallet.component.html
@@ -168,7 +168,7 @@
                     }}
                   </div>
                   <div class="text-grey8A fs-12px text-right">
-                    {{ globalVars.nanosToBitClout(creator.BalanceNanos, 4) }}
+                    {{ globalVars.nanosToBitClout(creator.BalanceNanos, 9) }}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
I use a slightly nonstandard approach with my creator coin in a 99.99 founder percentage. This surfaced an issue for visualizing holders of my coin which has an easy fix. I could also imagine the reverse case being important, my holders viewing their correct coin balance in the wallet.

This pull request shows example changes which would allow for the high creator coin percentage.

In making these changes I noticed that sometimes the creator coin significant figures are calculated through a global function, but, on the profile page this function was not used. This led me to think that the global balance formatting function should be used everywhere & the second numeric input should be removed.

In the meantime these changes could be simply merged as-is to support the rationalization of significant figures with a separate discussion about refactoring the approach to formatting.