### PR TITLE
use router for internal link if host matches

### DIFF
--- a/src/lib/pipes/sanitize-and-auto-link-pipe.ts
+++ b/src/lib/pipes/sanitize-and-auto-link-pipe.ts
@@ -45,6 +45,26 @@ export class SanitizeAndAutoLinkPipe implements PipeTransform {
       cashtagClass: AppComponent.DYNAMICALLY_ADDED_ROUTER_LINK_CLASS,
     });
 
-    return Autolinker.link(textWithMentionLinks);
+    return Autolinker.link(textWithMentionLinks, {
+      replaceFn : function(match) {
+        switch ( match.getType() ) {
+          case 'url':
+            //check if url to link matches current host, so its routed properly
+            const fullHost = (window as any).location.host;
+            if( match.getMatchedText().indexOf( fullHost ) !== -1 ) {
+              var tag = match.buildTag();
+              var rxStr = `https?://${fullHost}`
+              var re = RegExp(rxStr)
+              tag.setAttr( 'target', '_self' ); //dont open link in new window/tab
+              tag.setAttr( 'rel', 'nofollow' );
+              tag.setAttr('href',match.getMatchedText().replace(re,"").replace(/\?.*/,"")) //remove prefix & hostname & query string
+              tag.setClass(AppComponent.DYNAMICALLY_ADDED_ROUTER_LINK_CLASS) //add router class
+              return tag;
+            }
+        }
+        // let autolinker handle other links as needed 
+        return true;
+      }
+    });
   }
 }


### PR DESCRIPTION
This is a small enhanement to user experience when clicking on posts linking to node links, like bitclout posts. Right now these always open in a new tab, and require the "tap to load page" action. Instead they could use the router to speed up loading, and reduce system strain.

Here is what it looks like with the PR implemented (in this example on localhost of course due to development)

![routed-link](https://user-images.githubusercontent.com/69529928/117470341-9b22ef80-af4e-11eb-958a-25d2c006a984.gif)


Autolinker allows for custom function to run on matched link patterns. I used this to get links to open with router rather then in target=_blank.

Hopefully this is suitable.

Let me know if you want me to make any changes. 
