### PR TITLE
Prevent screen overflow on search dropdown

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -810,6 +810,8 @@ $green-font-color: #19B028;
   top: -22px;
   border: solid 1px $border-grey;
   z-index: 5; // the input has a z-index of 3 at one point.
+  max-height: 20rem;
+  overflow-y: scroll;
 }
 
 .search-bar__avatar {


### PR DESCRIPTION
Prevents behavior seen below that makes the search dropdown overflow viewport:

<img width="524" alt="Screenshot 2021-05-07 at 18 10 39" src="https://user-images.githubusercontent.com/4400527/117484856-8bf86d80-af5f-11eb-9a0b-fe8d2c42429d.png">
