### PR TITLE
cdd/Fix embed validation

### DIFF
--- a/src/lib/services/video-url-parser-service/video-url-parser-service.spec.ts
+++ b/src/lib/services/video-url-parser-service/video-url-parser-service.spec.ts
@@ -52,6 +52,8 @@ describe("VideoUrlParserService", () => {
     `https://www.youtube.com/watch?v=<script>somestuff</script>`,
     "http://vimeo.com/<b>123</b>",
     "123abc.com/1234556",
+    `https://wwwzyoutube.com/embed/${youtubeVideoID}`,
+    `https://nottiktok.com/embed/v2/${tiktokShortVideoID}`,
   ];
 
   it("parses youtube URLs from user input correctly and only validates embed urls", () => {

--- a/src/lib/services/video-url-parser-service/video-url-parser-service.ts
+++ b/src/lib/services/video-url-parser-service/video-url-parser-service.ts
@@ -118,7 +118,8 @@ export class VideoUrlParserService {
   }
 
   static isVimeoFromURL(url: URL): boolean {
-    return url.hostname.endsWith("vimeo.com");
+    const pattern = /\bvimeo\.com$/;
+    return pattern.test(url.hostname);
   }
 
   static isYoutubeLink(link: string): boolean {
@@ -131,7 +132,11 @@ export class VideoUrlParserService {
   }
 
   static isYoutubeFromURL(url: URL): boolean {
-    return url.hostname.endsWith("youtube.com") || url.hostname.endsWith("youtu.be");
+    const patterns = [
+      /\byoutube\.com$/,
+      /\byoutu\.be$/,
+    ];
+    return patterns.some(p => p.test(url.hostname));
   }
 
   static isTikTokLink(link: string): boolean {
@@ -144,7 +149,8 @@ export class VideoUrlParserService {
   }
 
   static isTiktokFromURL(url: URL): boolean {
-    return url.hostname.endsWith("tiktok.com");
+    const pattern = /\btiktok\.com$/;
+    return pattern.test(url.hostname);
   }
 
   static isValidVimeoEmbedURL(link: string) {

--- a/src/lib/services/video-url-parser-service/video-url-parser-service.ts
+++ b/src/lib/services/video-url-parser-service/video-url-parser-service.ts
@@ -153,7 +153,7 @@ export class VideoUrlParserService {
   }
 
   static isValidYoutubeEmbedURL(link: string) {
-    const regExp = /(https:\/\/www.youtube.com\/embed\/[A-Za-z0-9_-]{11})/;
+    const regExp = /(https:\/\/www\.youtube\.com\/embed\/[A-Za-z0-9_-]{11})/;
     return !!link.match(regExp);
   }
 


### PR DESCRIPTION
In the `VideoUrlParserService` class, there were a few places where validation wasn't specific enough.

Domains such as "wwwzyoutube.com" and "nottiktok.com" would have previously passed validation. On clients with a strong CSP, these are blocked by the browser. However, clients not configured with a CSP would possibly be open to injection of malicious iframes.

This PR improves the regular expressions used for validation, and adds some test cases (closer to what an adversary or penetration tester would try to input).