### PR TITLE
set header version to 1 when getting block template

### DIFF
--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -386,6 +386,7 @@ export class BackendApiService {
   GetBlockTemplate(endpoint: string, PublicKeyBase58Check: string): Observable<any> {
     return this.post(endpoint, BackendRoutes.RoutePathGetBlockTemplate, {
       PublicKeyBase58Check,
+      HeaderVersion: 1,
     });
   }
 


### PR DESCRIPTION
Currently admin panel receives a 400 response for not having the correct header version