### PR TITLE
fade text if longer then 280

### DIFF
--- a/src/app/feed/feed-post/feed-post.component.html
+++ b/src/app/feed/feed-post/feed-post.component.html
@@ -214,9 +214,10 @@
         </div>
 
         <!-- Content -->
+        <!-- TODO: Add a read more button for posts that are too long? -->
         <div
           class="roboto-regular mt-1"
-          [ngClass]="{ 'pb-10px': quotedContent && showQuotedContent }"
+          [ngClass]="{ 'pb-10px': quotedContent && showQuotedContent, 'feed-post__readmore': !isParentPostInThread && postContent.Body.length > maxPostLength }"
           style="
             overflow-wrap: anywhere;
             -ms-word-break: break-all;

--- a/src/app/feed/feed-post/feed-post.component.ts
+++ b/src/app/feed/feed-post/feed-post.component.ts
@@ -103,6 +103,9 @@ export class FeedPostComponent implements OnInit {
   _blocked: boolean;
   constructedEmbedVideoURL: any;
 
+  //max length to show of posts in feeds
+  maxPostLength = 260;
+
   ngOnInit() {
     if (this.globalVars.loggedInUser) {
       this.loggedInUserStakeAmount = this._getLoggedInUserStakeAmount();

--- a/src/app/feed/feed-post/feed-post.component.ts
+++ b/src/app/feed/feed-post/feed-post.component.ts
@@ -104,7 +104,7 @@ export class FeedPostComponent implements OnInit {
   constructedEmbedVideoURL: any;
 
   //max length to show of posts in feeds
-  maxPostLength = 260;
+  maxPostLength = 280;
 
   ngOnInit() {
     if (this.globalVars.loggedInUser) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1005,6 +1005,22 @@ $green-font-color: #19B028;
   width: 55%;
 }
 
+.feed-post__readmore {
+  max-height: 150px;
+  position: relative;
+  overflow: hidden;
+}
+
+.feed-post__readmore:after {
+    content:"";
+    position:absolute;
+    top:90px;
+    left:0;
+    height:60px;
+    width:100%;
+    background: linear-gradient(rgba(255, 255, 255, 0), #fff);
+}
+
 .left-bar__dot-active {
   font-size: 50px;
   line-height: 18px;


### PR DESCRIPTION
The feed is starting to get really hard to read sometimes with people using Cloutfeed and other tools to post long long posts with way more then the ~~260~~ 280 Max characters on the main node.

So I made this small amendment that fades out and hides body overflow on a feedpost if it is longer then ~~260~~ 280 chars.

Made sure its not hidden when viewing the actual post page, instead of feed.

Could be enhanced by adding a "read more" button, but i left that out for now. Left todo for that in comment.
