### PR TITLE
add verify & reserved badges to hodlr page

### DIFF
--- a/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.html
+++ b/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.html
@@ -14,7 +14,27 @@
           style="background-image: url('/assets/img/default_profile_pic.png')"
         ></div>
         <div class="d-flex flex-column">
-          <span class="text-truncate" [ngStyle]="usernameStyle()">{{ row.HODLerPublicKeyBase58Check }}</span>
+          <div class="d-flex align-items-center">
+            <span class="text-truncate" [ngStyle]="usernameStyle()">{{ row.HODLerPublicKeyBase58Check }}</span>
+            <span
+              *ngIf="row.ProfileEntryResponse.IsReserved && !row.ProfileEntryResponse.IsVerified"
+              class="d-inline-block ml-1 cursor-pointer lh-12px fc-muted"
+              matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
+              [matTooltip]="'This profile is reserved. Click to learn how to claim it.'"
+            >
+              <i class="far fa-clock fa-md align-middle"></i>
+            </span>
+            <span
+              *ngIf="row.ProfileEntryResponse.IsVerified"
+              (click)="tooltip.toggle()"
+              class="ml-1 cursor-pointer text-primary"
+              matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
+              [matTooltip]="'This account is verified'"
+              #tooltip="matTooltip"
+            >
+              <i class="fas fa-check-circle fa-md align-middle"></i>
+            </span>
+            </div>
           <div
             class="text-grey9"
             style="font-size: 10px"
@@ -45,7 +65,27 @@
           [style.background-image]="'url(' + row.ProfileEntryResponse.ProfilePic + ')'"
         ></div>
         <div class="d-flex flex-column">
-          <span class="text-truncate" [ngStyle]="usernameStyle()">{{ row.ProfileEntryResponse.Username }}</span>
+          <div class="d-flex align-items-center">
+            <span class="text-truncate" [ngStyle]="usernameStyle()">{{ row.ProfileEntryResponse.Username }}</span>
+            <span
+              *ngIf="row.ProfileEntryResponse.IsReserved && !row.ProfileEntryResponse.IsVerified"
+              class="d-inline-block ml-1 cursor-pointer lh-12px fc-muted"
+              matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
+              [matTooltip]="'This profile is reserved. Click to learn how to claim it.'"
+            >
+              <i class="far fa-clock fa-md align-middle"></i>
+            </span>
+            <span
+              *ngIf="row.ProfileEntryResponse.IsVerified"
+              (click)="tooltip.toggle()"
+              class="ml-1 cursor-pointer text-primary"
+              matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
+              [matTooltip]="'This account is verified'"
+              #tooltip="matTooltip"
+            >
+              <i class="fas fa-check-circle fa-md align-middle"></i>
+            </span>
+          </div>
           <div
             class="text-grey9"
             style="font-size: 10px"

--- a/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.html
+++ b/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.html
@@ -16,25 +16,7 @@
         <div class="d-flex flex-column">
           <div class="d-flex align-items-center">
             <span class="text-truncate" [ngStyle]="usernameStyle()">{{ row.HODLerPublicKeyBase58Check }}</span>
-            <span
-              *ngIf="row.ProfileEntryResponse.IsReserved && !row.ProfileEntryResponse.IsVerified"
-              class="d-inline-block ml-1 cursor-pointer lh-12px fc-muted"
-              matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
-              [matTooltip]="'This profile is reserved. Click to learn how to claim it.'"
-            >
-              <i class="far fa-clock fa-md align-middle"></i>
-            </span>
-            <span
-              *ngIf="row.ProfileEntryResponse.IsVerified"
-              (click)="tooltip.toggle()"
-              class="ml-1 cursor-pointer text-primary"
-              matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
-              [matTooltip]="'This account is verified'"
-              #tooltip="matTooltip"
-            >
-              <i class="fas fa-check-circle fa-md align-middle"></i>
-            </span>
-            </div>
+          </div>
           <div
             class="text-grey9"
             style="font-size: 10px"
@@ -69,21 +51,21 @@
             <span class="text-truncate" [ngStyle]="usernameStyle()">{{ row.ProfileEntryResponse.Username }}</span>
             <span
               *ngIf="row.ProfileEntryResponse.IsReserved && !row.ProfileEntryResponse.IsVerified"
-              class="d-inline-block ml-1 cursor-pointer lh-12px fc-muted"
+              class="d-inline-block ml-1 cursor-pointer lh-12px fc-muted align-middle"
               matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
               [matTooltip]="'This profile is reserved. Click to learn how to claim it.'"
             >
-              <i class="far fa-clock fa-md align-middle"></i>
+              <i class="far fa-clock fa-md"></i>
             </span>
             <span
               *ngIf="row.ProfileEntryResponse.IsVerified"
               (click)="tooltip.toggle()"
-              class="ml-1 cursor-pointer text-primary"
+              class="ml-1 cursor-pointer text-primary align-middle"
               matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
               [matTooltip]="'This account is verified'"
               #tooltip="matTooltip"
             >
-              <i class="fas fa-check-circle fa-md align-middle"></i>
+              <i class="fas fa-check-circle fa-md"></i>
             </span>
           </div>
           <div

--- a/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.html
+++ b/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.html
@@ -14,9 +14,7 @@
           style="background-image: url('/assets/img/default_profile_pic.png')"
         ></div>
         <div class="d-flex flex-column">
-          <div class="d-flex align-items-center">
-            <span class="text-truncate" [ngStyle]="usernameStyle()">{{ row.HODLerPublicKeyBase58Check }}</span>
-          </div>
+          <span class="text-truncate" [ngStyle]="usernameStyle()">{{ row.HODLerPublicKeyBase58Check }}</span>
           <div
             class="text-grey9"
             style="font-size: 10px"

--- a/src/app/right-bar-creators/right-bar-creators-leaderboard/right-bar-creators-leaderboard.component.html
+++ b/src/app/right-bar-creators/right-bar-creators-leaderboard/right-bar-creators-leaderboard.component.html
@@ -33,7 +33,7 @@
       matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
       [matTooltip]="'This profile is reserved. Click to learn how to claim it.'"
     >
-      <i class="far fa-clock fa-md align-middle"></i>
+      <i class="far fa-clock fa-md"></i>
     </span>
     <span
       *ngIf="profileEntryResponse.Profile.IsVerified"
@@ -43,7 +43,7 @@
       [matTooltip]="'This account is verified'"
       #tooltip="matTooltip"
     >
-      <i class="fas fa-check-circle fa-md align-middle"></i>
+      <i class="fas fa-check-circle fa-md"></i>
     </span>
   </div>
 

--- a/src/app/trade-creator-page/trade-creator/trade-creator.component.html
+++ b/src/app/trade-creator-page/trade-creator/trade-creator.component.html
@@ -18,27 +18,29 @@
             ')'
           "
         ></a>
-        <div *ngIf="screenToShow == this.TRADE_CREATOR_FORM_SCREEN" class="font-weight-bold fs-18px">
-          {{ creatorCoinTrade.tradeVerbString() }}  {{ creatorCoinTrade.creatorProfile.Username }} coin
-        </div>
-        <span
-          *ngIf="creatorCoinTrade.creatorProfile.IsReserved && !creatorCoinTrade.creatorProfile.IsVerified"
-          class="d-inline-block ml-1 cursor-pointer lh-12px fc-muted"
-          matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
-          [matTooltip]="'This profile is reserved. Click to learn how to claim it.'"
-        >
-          <i class="far fa-clock fa-md align-middle"></i>
-        </span>
-        <span
-          *ngIf="creatorCoinTrade.creatorProfile.IsVerified"
-          (click)="tooltip.toggle()"
-          class="ml-1 cursor-pointer text-primary"
-          matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
-          [matTooltip]="'This account is verified'"
-          #tooltip="matTooltip"
-        >
-          <i class="fas fa-check-circle fa-md align-middle"></i>
-        </span>  
+        <p *ngIf="screenToShow == this.TRADE_CREATOR_FORM_SCREEN" class="font-weight-bold fs-18px">
+          {{ creatorCoinTrade.tradeVerbString() }}
+          <span>{{ creatorCoinTrade.creatorProfile.Username }}</span>
+          <span
+            *ngIf="creatorCoinTrade.creatorProfile.IsReserved && !creatorCoinTrade.creatorProfile.IsVerified"
+            class="ml-5px d-inline-block cursor-pointer lh-12px fc-muted"
+            matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
+            [matTooltip]="'This profile is reserved. Click to learn how to claim it.'"
+          >
+            <i class="far fa-clock fa-md"></i>
+          </span>
+          <span
+            *ngIf="creatorCoinTrade.creatorProfile.IsVerified"
+            (click)="tooltip.toggle()"
+            class="ml-5px cursor-pointer text-primary"
+            matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
+            [matTooltip]="'This account is verified'"
+            #tooltip="matTooltip"
+          >
+            <i class="fas fa-check-circle fa-md"></i>
+          </span>
+          coin
+        </p>
 
         <span *ngIf="screenToShow == this.TRADE_CREATOR_PREVIEW_SCREEN">
           Confirm Coin

--- a/src/app/trade-creator-page/trade-creator/trade-creator.component.html
+++ b/src/app/trade-creator-page/trade-creator/trade-creator.component.html
@@ -18,10 +18,27 @@
             ')'
           "
         ></a>
-
         <div *ngIf="screenToShow == this.TRADE_CREATOR_FORM_SCREEN" class="font-weight-bold fs-18px">
-          {{ creatorCoinTrade.tradeVerbString() }} {{ creatorCoinTrade.creatorProfile.Username }} coin
+          {{ creatorCoinTrade.tradeVerbString() }}  {{ creatorCoinTrade.creatorProfile.Username }} coin
         </div>
+        <span
+          *ngIf="creatorCoinTrade.creatorProfile.IsReserved && !creatorCoinTrade.creatorProfile.IsVerified"
+          class="d-inline-block ml-1 cursor-pointer lh-12px fc-muted"
+          matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
+          [matTooltip]="'This profile is reserved. Click to learn how to claim it.'"
+        >
+          <i class="far fa-clock fa-md align-middle"></i>
+        </span>
+        <span
+          *ngIf="creatorCoinTrade.creatorProfile.IsVerified"
+          (click)="tooltip.toggle()"
+          class="ml-1 cursor-pointer text-primary"
+          matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
+          [matTooltip]="'This account is verified'"
+          #tooltip="matTooltip"
+        >
+          <i class="fas fa-check-circle fa-md align-middle"></i>
+        </span>  
 
         <span *ngIf="screenToShow == this.TRADE_CREATOR_PREVIEW_SCREEN">
           Confirm Coin


### PR DESCRIPTION
Latest scam seems to use fake profiles that look like verified usernames with same profile image in holder page of scam / rug pull coins. 

Several users suggested adding the verified badge to the view of hodlr.

This achieves that. Hopefully. 