### PR TITLE
Added Dynamic Profile Username Titles and Titles for all pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitclout-frontend",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/admin/admin.component.html
+++ b/src/app/admin/admin.component.html
@@ -1,4 +1,5 @@
 <div *ngIf="globalVars.nodeInfo != null">
+  {{ setTitle('Admin - BitClout') }}
   <!-- Top Bar -->
   <div
     *ngIf="!isMobile"

--- a/src/app/admin/admin.component.ts
+++ b/src/app/admin/admin.component.ts
@@ -5,6 +5,7 @@ import { BackendApiService, ProfileEntryResponse } from "../backend-api.service"
 import { sprintf } from "sprintf-js";
 import { SwalHelper } from "../../lib/helpers/swal-helper";
 import * as _ from "lodash";
+import { Title } from '@angular/platform-browser';
 
 class Messages {
   static INCORRECT_PASSWORD = `The password you entered was incorrect.`;
@@ -127,7 +128,8 @@ export class AdminComponent implements OnInit {
     private _globalVars: GlobalVarsService,
     private router: Router,
     private route: ActivatedRoute,
-    private backendApi: BackendApiService
+    private backendApi: BackendApiService,
+    private titleService: Title,
   ) {
     this.globalVars = _globalVars;
   }
@@ -1037,5 +1039,10 @@ export class AdminComponent implements OnInit {
           });
       }
     });
+  }
+
+  // Set Title function for dynamically setting the title
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { IdentityService } from "./identity.service";
 import * as _ from "lodash";
 import { environment } from "../environments/environment";
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: "app-root",
@@ -20,7 +21,8 @@ export class AppComponent implements OnInit {
     public globalVars: GlobalVarsService,
     private route: ActivatedRoute,
     public identityService: IdentityService,
-    private router: Router
+    private router: Router,
+    private titleService: Title,
   ) {
     this.globalVars.Init(
       null, // loggedInUser
@@ -51,6 +53,11 @@ export class AppComponent implements OnInit {
   showUsernameTooltip = false;
 
   bitcloutToUSDExchangeRateToDisplay = "fetching...";
+
+  // Set Title function for dynamically setting the title
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
+  }
 
   // Throttle the calls to update the top-level data so they only happen after a
   // previous call has finished.

--- a/src/app/buy-bitclout-page/buy-bitclout-page.component.html
+++ b/src/app/buy-bitclout-page/buy-bitclout-page.component.html
@@ -1,5 +1,6 @@
 <app-page>
   <div *ngIf="globalVars.loggedInUser; else elseBlock">
+    {{ setTitle('Buy $BitClout - BitClout') }}
     <buy-bitclout></buy-bitclout>
   </div>
   <ng-template #elseBlock>

--- a/src/app/buy-bitclout-page/buy-bitclout-page.component.ts
+++ b/src/app/buy-bitclout-page/buy-bitclout-page.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from "@angular/core";
 import { GlobalVarsService } from "../global-vars.service";
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: "buy-bitclout-page",
@@ -9,5 +10,10 @@ import { GlobalVarsService } from "../global-vars.service";
 export class BuyBitcloutPageComponent {
   isLeftBarMobileOpen: boolean = false;
 
-  constructor(public globalVars: GlobalVarsService) {}
+  constructor(public globalVars: GlobalVarsService, private titleService: Title) {}
+
+  // Set Title function for dynamically setting the title
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
+  }
 }

--- a/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.html
+++ b/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.html
@@ -4,7 +4,9 @@
 <not-found *ngIf="!profile && !loading"></not-found>
 
 <div *ngIf="profile && !loading" class="flex-grow-1">
-  {{ setTitle(profile.Username+' - BitClout') }}
+  {{ setTitle(profile.Username+' on BitClout') }}
+  {{ setMeta('@'+profile.Username+' on BitClout') }}
+  {{ setMetaDesc(profile.Description) }}
   <!-- Top Card With Creator Info -->
   <creator-profile-top-card
     *ngIf="profile && !loading"

--- a/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.html
+++ b/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.html
@@ -4,6 +4,7 @@
 <not-found *ngIf="!profile && !loading"></not-found>
 
 <div *ngIf="profile && !loading" class="flex-grow-1">
+  {{ setTitle(profile.Username+' - BitClout') }}
   <!-- Top Card With Creator Info -->
   <creator-profile-top-card
     *ngIf="profile && !loading"

--- a/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.ts
+++ b/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.ts
@@ -5,7 +5,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { Location } from "@angular/common";
 import { SwalHelper } from "../../../lib/helpers/swal-helper";
 import { CreatorProfileTopCardComponent } from "../creator-profile-top-card/creator-profile-top-card.component";
-import { Title } from '@angular/platform-browser';
+import { Title, Meta } from '@angular/platform-browser';
 
 @Component({
   selector: "creator-profile-details",
@@ -44,6 +44,7 @@ export class CreatorProfileDetailsComponent {
     private router: Router,
     private location: Location,
     private titleService: Title,
+    private metaService: Meta,
   ) {
     this.route.params.subscribe((params) => {
       this.userName = params.username;
@@ -205,5 +206,18 @@ export class CreatorProfileDetailsComponent {
   // Set Title function for dynamically setting the title
   public setTitle(newTitle: string) {
     this.titleService.setTitle(newTitle);
+  }
+
+  // Set Meta function for dynamically setting the meta tags
+  public setMeta(newContent: string) {
+    this.metaService.addTag({ property: 'og:title', content: newContent});
+    this.metaService.addTag({ property: 'og:type', content: 'article'});
+    this.metaService.addTag({ property: 'al:ios:app_name', content: 'BitClout'});
+    this.metaService.addTag({ property: 'al:android:app_name', content: 'BitClout'});
+  }
+
+  // Set Meta function for dynamically setting the meta tags
+  public setMetaDesc(newContent: string) {
+    this.metaService.addTag({ property: 'og:description', content: newContent});
   }
 }

--- a/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.ts
+++ b/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { Location } from "@angular/common";
 import { SwalHelper } from "../../../lib/helpers/swal-helper";
 import { CreatorProfileTopCardComponent } from "../creator-profile-top-card/creator-profile-top-card.component";
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: "creator-profile-details",
@@ -41,7 +42,8 @@ export class CreatorProfileDetailsComponent {
     private route: ActivatedRoute,
     private cdr: ChangeDetectorRef,
     private router: Router,
-    private location: Location
+    private location: Location,
+    private titleService: Title,
   ) {
     this.route.params.subscribe((params) => {
       this.userName = params.username;
@@ -198,5 +200,10 @@ export class CreatorProfileDetailsComponent {
       !this.globalVars.loggedInUser?.ProfileEntryResponse?.Username &&
       this.globalVars.loggedInUser?.UsersYouHODL?.length === 0
     );
+  }
+
+  // Set Title function for dynamically setting the title
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
   }
 }

--- a/src/app/creators-leaderboard/creators-leaderboard/creators-leaderboard.component.html
+++ b/src/app/creators-leaderboard/creators-leaderboard/creators-leaderboard.component.html
@@ -10,7 +10,7 @@
 
     <top-bar-mobile-log-in-or-sign-up></top-bar-mobile-log-in-or-sign-up>
   </div>
-
+  {{ setTitle('Buy Creator Coins - BitClout') }}
   <!--Header Desktop-->
   <div class="d-none d-lg-block w-100 px-15px fs-18px font-weight-bold fc-default border-bottom border-color-grey">
     <div class="d-flex align-items-center justify-content-between">

--- a/src/app/creators-leaderboard/creators-leaderboard/creators-leaderboard.component.ts
+++ b/src/app/creators-leaderboard/creators-leaderboard/creators-leaderboard.component.ts
@@ -4,6 +4,7 @@ import { BackendApiService } from "../../backend-api.service";
 import { AppRoutingModule } from "../../app-routing.module";
 import { CanPublicKeyFollowTargetPublicKeyHelper } from "../../../lib/helpers/follows/can_public_key_follow_target_public_key_helper";
 import { Datasource, IDatasource } from "ngx-ui-scroll";
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: "creators-leaderboard",
@@ -81,7 +82,7 @@ export class CreatorsLeaderboardComponent implements OnInit {
     },
   });
 
-  constructor(private globalVars: GlobalVarsService, private backendApi: BackendApiService) {
+  constructor(private globalVars: GlobalVarsService, private backendApi: BackendApiService, private titleService: Title) {
     this.appData = globalVars;
   }
 
@@ -144,5 +145,10 @@ export class CreatorsLeaderboardComponent implements OnInit {
       this.appData.loggedInUser.PublicKeyBase58Check,
       targetPubKeyBase58Check
     );
+  }
+
+  // Set Title function for dynamically setting the title
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
   }
 }

--- a/src/app/feed/feed.component.html
+++ b/src/app/feed/feed.component.html
@@ -9,7 +9,7 @@
       Home
     </div>
   </div>
-
+  {{ setTitle('Feed - BitClout') }}
   <div class="global__top-bar__height"></div>
 
   <div *ngIf="!isMobile">

--- a/src/app/feed/feed.component.ts
+++ b/src/app/feed/feed.component.ts
@@ -6,6 +6,7 @@ import { Subscription } from "rxjs";
 import { tap, finalize, first } from "rxjs/operators";
 import * as _ from "lodash";
 import PullToRefresh from "pulltorefreshjs";
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: "feed",
@@ -63,7 +64,8 @@ export class FeedComponent implements OnInit, OnDestroy, AfterViewChecked {
     private router: Router,
     private route: ActivatedRoute,
     private cdr: ChangeDetectorRef,
-    private backendApi: BackendApiService
+    private backendApi: BackendApiService,
+    private titleService: Title,
   ) {
     this.globalVars = appData;
 
@@ -504,5 +506,10 @@ export class FeedComponent implements OnInit, OnDestroy, AfterViewChecked {
     // Add the post to the parent's list of comments so that the comment count gets updated
     parentPost.Comments = parentPost.Comments || [];
     parentPost.Comments.unshift(postEntryResponse);
+  }
+
+  // Set Title function for dynamically setting the title
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
   }
 }

--- a/src/app/messages-page/messages-page.component.html
+++ b/src/app/messages-page/messages-page.component.html
@@ -1,6 +1,7 @@
 <!--
   DESKTOP
   -->
+{{ setTitle('Messages - BitClout') }}
 <div class="global__desktop" *ngIf="!globalVars.isMobile()">
   <left-bar></left-bar>
 

--- a/src/app/messages-page/messages-page.component.ts
+++ b/src/app/messages-page/messages-page.component.ts
@@ -4,6 +4,7 @@ import { AppRoutingModule } from "../app-routing.module";
 import { Datasource, IDatasource } from "ngx-ui-scroll";
 import { BackendApiService } from "../backend-api.service";
 import { Router } from "@angular/router";
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: "app-messages-page",
@@ -19,7 +20,7 @@ export class MessagesPageComponent {
   showThreadView = false;
   AppRoutingModule = AppRoutingModule;
 
-  constructor(public globalVars: GlobalVarsService, private backendApi: BackendApiService, private router: Router) {}
+  constructor(public globalVars: GlobalVarsService, private backendApi: BackendApiService, private router: Router, private titleService: Title,) {}
 
   _handleMessageThreadSelectedMobile(thread: any) {
     if (!thread) {
@@ -73,5 +74,10 @@ export class MessagesPageComponent {
   navigateToInbox() {
     this.selectedThread = null;
     this.showThreadView = false;
+  }
+
+  // Set Title function for dynamically setting the title
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
   }
 }

--- a/src/app/notifications-page/notifications-page.component.html
+++ b/src/app/notifications-page/notifications-page.component.html
@@ -1,3 +1,4 @@
 <app-page>
+    {{ setTitle('Notifications - BitClout') }}
   <app-notifications-list></app-notifications-list>
 </app-page>

--- a/src/app/notifications-page/notifications-page.component.ts
+++ b/src/app/notifications-page/notifications-page.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from "@angular/core";
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: "app-notifications-page",
@@ -6,5 +7,10 @@ import { Component, OnInit } from "@angular/core";
   styleUrls: ["./notifications-page.component.scss"],
 })
 export class NotificationsPageComponent {
-  constructor() {}
+  constructor(private titleService: Title) { }
+  
+  // Set Title function for dynamically setting the title
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
+  }
 }

--- a/src/app/pick-a-coin-page/pick-a-coin-page.component.html
+++ b/src/app/pick-a-coin-page/pick-a-coin-page.component.html
@@ -6,7 +6,7 @@
     <top-bar-mobile-navigation-control class="mr-15px d-lg-none d-inline-block"></top-bar-mobile-navigation-control>
     Send Creator Coins
   </div>
-
+  {{ setTitle('Send Creator Coins - BitClout') }}
   <div class="global__top-bar__height"></div>
 
   <!-- Creator Coins Divider Bar -->

--- a/src/app/pick-a-coin-page/pick-a-coin-page.component.ts
+++ b/src/app/pick-a-coin-page/pick-a-coin-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from "@angular/core";
 import { GlobalVarsService } from "../global-vars.service";
 import { AppRoutingModule } from "../app-routing.module";
+import { Title } from "@angular/platform-browser";
 
 @Component({
   selector: "app-pick-a-coin-page",
@@ -11,7 +12,7 @@ export class PickACoinPageComponent implements OnInit {
   AppRoutingModule = AppRoutingModule;
   hasUnminedCreatorCoins: boolean;
 
-  constructor(private appData: GlobalVarsService) {
+  constructor(private appData: GlobalVarsService, private titleService: Title) {
     this.globalVars = appData;
   }
 
@@ -32,5 +33,10 @@ export class PickACoinPageComponent implements OnInit {
       );
     });
     return creators;
+  }
+
+  // Set Title function for dynamically setting the title
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
   }
 }

--- a/src/app/post-thread-page/post-thread/post-thread.component.html
+++ b/src/app/post-thread-page/post-thread/post-thread.component.html
@@ -1,6 +1,9 @@
 <!-- Top Bar -->
 <!-- FIXME: TODO: post threads: loading skeletons -->
 <div *ngIf="currentPost" style="padding-bottom: 20vh" class="d-flex flex-column">
+{{ setTitle(currentPost.ProfileEntryResponse.Username+' on BitClout: "'+ currentPost.Body+'"') }}
+{{ setMeta('@'+currentPost.ProfileEntryResponse.Username+' on BitClout') }}
+{{ setMetaDesc(currentPost.Body) }}
   <div
     class="global__top-bar d-flex align-items-center justify-content-between fs-18px font-weight-bold px-15px border-bottom border-color-grey"
   >

--- a/src/app/post-thread-page/post-thread/post-thread.component.ts
+++ b/src/app/post-thread-page/post-thread/post-thread.component.ts
@@ -5,6 +5,7 @@ import { BackendApiService } from "../../backend-api.service";
 import { FeedComponent } from "../../feed/feed.component";
 import { Datasource, IDatasource, IAdapter } from "ngx-ui-scroll";
 import { ToastrService } from "ngx-toastr";
+import { Meta, Title, MetaDefinition } from '@angular/platform-browser';
 
 import * as _ from "lodash";
 
@@ -27,7 +28,9 @@ export class PostThreadComponent {
     public globalVars: GlobalVarsService,
     private backendApi: BackendApiService,
     private changeRef: ChangeDetectorRef,
-    private toastr: ToastrService
+    private toastr: ToastrService,
+    private titleService: Title,
+    private metaService:Meta,
   ) {
     // This line forces the component to reload when only a url param changes.  Without this, the UiScroll component
     // behaves strangely and can reuse data from a previous post.
@@ -329,5 +332,23 @@ export class PostThreadComponent {
 
   afterUserBlocked(blockedPubKey: any) {
     this.globalVars.loggedInUser.BlockedPubKeys[blockedPubKey] = {};
+  }
+
+  // Set Title function for dynamically setting the title
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
+  }
+
+  // Set Meta function for dynamically setting the meta tags
+  public setMeta(newContent: string) {
+    this.metaService.addTag({ property: 'og:title', content: newContent});
+    this.metaService.addTag({ property: 'og:type', content: 'article'});
+    this.metaService.addTag({ property: 'al:ios:app_name', content: 'BitClout'});
+    this.metaService.addTag({ property: 'al:android:app_name', content: 'BitClout'});
+  }
+
+  // Set Meta function for dynamically setting the meta tags
+  public setMetaDesc(newContent: string) {
+    this.metaService.addTag({ property: 'og:description', content: newContent});
   }
 }

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -5,7 +5,7 @@
   <top-bar-mobile-navigation-control class="mr-15px d-lg-none d-inline-block"></top-bar-mobile-navigation-control>
   Settings
 </div>
-
+{{ setTitle('Settings - BitClout') }}
 <div class="global__top-bar__height"></div>
 
 <div class="d-flex flex-column">

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from "@angular/core";
 import { GlobalVarsService } from "../global-vars.service";
 import { BackendApiService } from "../backend-api.service";
 import { CountryISO } from "ngx-intl-tel-input";
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: "settings",
@@ -17,7 +18,7 @@ export class SettingsComponent implements OnInit {
   showSuccessMessage = false;
   successMessageTimeout: any;
 
-  constructor(public globalVars: GlobalVarsService, private backendApi: BackendApiService) {}
+  constructor(public globalVars: GlobalVarsService, private backendApi: BackendApiService, private titleService: Title,) {}
 
   ngOnInit() {
     this._getUserMetadata();
@@ -78,5 +79,10 @@ export class SettingsComponent implements OnInit {
           this.showSuccessMessage = false;
         }, 500);
       });
+  }
+
+  // Set Title function for dynamically setting the title
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
   }
 }

--- a/src/app/transfer-bitclout/transfer-bitclout.component.html
+++ b/src/app/transfer-bitclout/transfer-bitclout.component.html
@@ -6,7 +6,7 @@
 
   Send $BitClout
 </div>
-
+{{ setTitle('Send $BitClout - BitClout') }}
 <!-- Explainer -->
 <div
   class="d-flex align-items-center fs-15px fc-muted p-15px border-bottom border-color-grey background-color-light-grey"

--- a/src/app/transfer-bitclout/transfer-bitclout.component.ts
+++ b/src/app/transfer-bitclout/transfer-bitclout.component.ts
@@ -3,6 +3,7 @@ import { BackendApiService } from "../backend-api.service";
 import { GlobalVarsService } from "../global-vars.service";
 import { sprintf } from "sprintf-js";
 import { SwalHelper } from "../../lib/helpers/swal-helper";
+import { Title } from '@angular/platform-browser';
 
 class Messages {
   static INCORRECT_PASSWORD = `The password you entered was incorrect.`;
@@ -33,7 +34,7 @@ export class TransferBitcloutComponent implements OnInit {
   loadingMax = false;
   sendingBitClout = false;
 
-  constructor(private backendApi: BackendApiService, private globalVarsService: GlobalVarsService) {
+  constructor(private backendApi: BackendApiService, private globalVarsService: GlobalVarsService, private titleService: Title) {
     this.globalVars = globalVarsService;
   }
 
@@ -290,4 +291,10 @@ export class TransferBitcloutComponent implements OnInit {
     // errorString.
     return JSON.stringify(err);
   }
+
+  // Set Title function for dynamically setting the title
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
+  }
+
 }

--- a/src/app/update-profile-page/update-profile/update-profile.component.html
+++ b/src/app/update-profile-page/update-profile/update-profile.component.html
@@ -5,7 +5,7 @@
   <top-bar-mobile-navigation-control class="mr-15px d-lg-none d-inline-block"></top-bar-mobile-navigation-control>
   Update Profile
 </div>
-
+{{ setTitle('Update Profile - BitClout') }}
 <div class="global__top-bar__height"></div>
 
 <div *ngIf="this.loggedInUser.CanCreateProfile; else elseBlock">

--- a/src/app/update-profile-page/update-profile/update-profile.component.ts
+++ b/src/app/update-profile-page/update-profile/update-profile.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { BackendApiService } from "../../backend-api.service";
 import { SwalHelper } from "../../../lib/helpers/swal-helper";
 import { RouteNames } from "../../app-routing.module";
+import { Title } from '@angular/platform-browser';
 
 export type ProfileUpdates = {
   usernameUpdate: string;
@@ -48,7 +49,8 @@ export class UpdateProfileComponent implements OnInit, OnChanges {
     public globalVars: GlobalVarsService,
     private route: ActivatedRoute,
     private backendApi: BackendApiService,
-    private router: Router
+    private router: Router,
+    private titleService: Title,
   ) {}
 
   ngOnInit() {
@@ -246,5 +248,10 @@ export class UpdateProfileComponent implements OnInit, OnChanges {
 
   _resetImage() {
     this.profilePicInput = "";
+  }
+
+  // Set Title function for dynamically setting the title
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
   }
 }

--- a/src/app/wallet/wallet.component.html
+++ b/src/app/wallet/wallet.component.html
@@ -6,7 +6,7 @@
     <top-bar-mobile-navigation-control class="mr-15px d-lg-none d-inline-block"></top-bar-mobile-navigation-control>
     Wallet
   </div>
-
+  {{ setTitle('Wallet - BitClout') }}
   <div class="global__top-bar__height"></div>
 
   <div class="d-flex flex-column" *ngIf="globalVars.loggedInUser">

--- a/src/app/wallet/wallet.component.ts
+++ b/src/app/wallet/wallet.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from "@angular/core";
 import { GlobalVarsService } from "../global-vars.service";
 import { AppRoutingModule } from "../app-routing.module";
 import { BalanceEntryResponse } from "../backend-api.service";
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: "wallet",
@@ -21,7 +22,7 @@ export class WalletComponent implements OnInit {
   tabs = [WalletComponent.coinsPurchasedTab, WalletComponent.coinsReceivedTab];
   activeTab: string = WalletComponent.coinsPurchasedTab;
 
-  constructor(private appData: GlobalVarsService) {
+  constructor(private appData: GlobalVarsService, private titleService: Title,) {
     this.globalVars = appData;
   }
 
@@ -104,5 +105,10 @@ export class WalletComponent implements OnInit {
   _handleTabClick(tab: string) {
     this.showTransferredCoins = tab === WalletComponent.coinsReceivedTab;
     this.activeTab = tab;
+  }
+
+  // Set Title function for dynamically setting the title
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
   }
 }


### PR DESCRIPTION
This gives the feature of titles on pages for BitClout vs. the old every page being "Welcome to BitClout"

This also gives dynamic profile username pages so for example my https://bitclout.com/u/carsenk will now have the title of my creator coin/username

Example preview:
![IqscY0GCo8](https://user-images.githubusercontent.com/10162347/120911126-d8f46000-c641-11eb-800e-da4e41572b40.gif)

I will be adding a PR next for dynamic Twitter OG Metatags so that BitClout posts and pages show up on social media sites similar to how other modern sites or aka Twitter does.

💎🤲💎🤲💎🤲
