### PR TITLE
Add Total Hodled Amount on Right Sidebar

### DIFF
--- a/src/app/right-bar-creators/right-bar-creators.component.html
+++ b/src/app/right-bar-creators/right-bar-creators.component.html
@@ -35,6 +35,20 @@
         </div>
       </div>
     </div>
+    <div *ngIf="globalVars.loggedInUser" class="d-flex justify-content-between pt-10px">
+      <div class="d-flex" style="min-width: 150px">Total Hodled</div>
+      <div class="d-flex align-items-center justify-content-end flex-wrap">
+        <div>
+          <!-- Amount in BitClout-->
+          ≈  {{ globalVars.nanosToUSD(totalValue(), 2) }}
+        </div>
+
+        <div class="d-flex text-muted">
+          <!-- Amount in USD-->
+          <div class="ml-10px">USD</div>
+        </div>
+      </div>
+    </div>
   </div>
 
   <!-- Sign Up Flow -->

--- a/src/app/right-bar-creators/right-bar-creators.component.ts
+++ b/src/app/right-bar-creators/right-bar-creators.component.ts
@@ -69,4 +69,18 @@ export class RightBarCreatorsComponent implements OnInit {
       this.backendApi.SetStorage(RightBarCreatorsComponent.RightBarTabKey, this.activeTab);
     }
   }
+
+  totalValue() {
+    let result = 0;
+
+    for (const holding of this.globalVars.loggedInUser.UsersYouHODL) {
+      result +=
+        this.globalVars.bitcloutNanosYouWouldGetIfYouSold(
+          holding.BalanceNanos,
+          holding.ProfileEntryResponse.CoinEntry
+        ) || 0;
+    }
+
+    return result;
+  }
 }


### PR DESCRIPTION
Adds "Total Hodled" on the right sidebar, beginning of additional stats, ideally creator coin amount held and current creator price.

Preview:
![image](https://user-images.githubusercontent.com/10162347/121304846-182ce600-c8ba-11eb-844c-a0885bee6139.png)
