### PR TITLE
switch to $clout

### DIFF
--- a/src/app/buy-bitclout-page/buy-bitclout-complete/buy-bitclout-complete.component.html
+++ b/src/app/buy-bitclout-page/buy-bitclout-complete/buy-bitclout-complete.component.html
@@ -11,7 +11,7 @@
 <div class="fs-15px px-15px pt-25px pb-30px">
   <div class="font-weight-bold fs-24px mb-15px">
     New balance:
-    {{ globalVars.nanosToBitClout(globalVars.loggedInUser.BalanceNanos, 9) }} $BitClout
+    {{ globalVars.nanosToBitClout(globalVars.loggedInUser.BalanceNanos, 9) }} $Clout
   </div>
 
   <a
@@ -23,7 +23,7 @@
   </a>
 
   <div class="text-grey7 mt-15px">
-    Use $BitClout to buy creator coins. Collect your favorite creators and get on their team!
+    Use $Clout to buy creator coins. Collect your favorite creators and get on their team!
   </div>
 </div>
 
@@ -57,7 +57,7 @@
       (click)="triggerBuyMoreBitclout()"
       queryParamsHandling="merge"
     >
-      Buy more $BitClout »
+      Buy more $Clout »
     </a>
   </div>
 </div>

--- a/src/app/buy-bitclout-page/buy-bitclout-logged-out/buy-bitclout-logged-out.component.html
+++ b/src/app/buy-bitclout-page/buy-bitclout-logged-out/buy-bitclout-logged-out.component.html
@@ -15,7 +15,7 @@
     <div class="global__top-bar__height"></div>
     <!-- Description, Logged Out -->
     <div *ngIf="!globalVars.loggedInUser" class="fc-default fs-15px mt-30px pr-15px ml-15px pb-30px">
-      $BitClout is a cryptocurrency like Bitcoin, only it powers the first decentralized social network.
+      BitClout is a cryptocurrency like Bitcoin, only it powers the first decentralized social network.
     </div>
 
     <!-- Spacer -->
@@ -27,13 +27,13 @@
         class="fs-18px fc-default font-weight-bold ml-15px buy-bitclout__box-label-adjustment"
         style="background-color: white"
       >
-        How do I get $BitClout?
+        How do I get $Clout?
       </div>
       <div>
         <div class="d-flex w-100 mt-5px pl-15px fs-15px pb-15px pr-30px">
           <div style="min-width: 120px">
             <a (click)="globalVars.launchSignupFlow()">Create an anonymous account</a>
-            to buy $BitClout in under a minute.
+            to buy $Clout in under a minute.
           </div>
         </div>
       </div>
@@ -47,7 +47,7 @@
         class="fs-18px mb-10px fc-default font-weight-bold ml-15px buy-bitclout__box-label-adjustment"
         style="background-color: white"
       >
-        What is $BitClout useful for?
+        What is $Clout useful for?
       </div>
       <div>
         <div class="d-flex w-100 pl-15px pt-15px pb-15px fs-15px buy-bitclout__amount-background">

--- a/src/app/buy-bitclout-page/buy-bitclout-page.component.ts
+++ b/src/app/buy-bitclout-page/buy-bitclout-page.component.ts
@@ -11,7 +11,7 @@ export class BuyBitcloutPageComponent implements OnInit {
   isLeftBarMobileOpen: boolean = false;
 
   ngOnInit() {
-    this.titleService.setTitle("Buy $BitClout - BitClout");
+    this.titleService.setTitle("Buy $Clout - BitClout");
   }
 
   constructor(public globalVars: GlobalVarsService, private titleService: Title) {}

--- a/src/app/buy-bitclout-page/buy-bitclout/buy-bitclout.component.html
+++ b/src/app/buy-bitclout-page/buy-bitclout/buy-bitclout.component.html
@@ -173,9 +173,9 @@
             <!-- BitClout to buy input-->
             <div class="pl-15px pr-15px pt-5px">
               <div class="d-flex w-100 fs-18px font-weight-bold">
-                <div style="min-width: 120px">Buy $BitClout with Bitcoin</div>
+                <div style="min-width: 120px">Buy $Clout with Bitcoin</div>
               </div>
-              <div class="fs-15px mt-20px font-weight-bold">$BitClout to buy</div>
+              <div class="fs-15px mt-20px font-weight-bold">$Clout to buy</div>
               <div class="pt-5px d-flex align-items-center justify-content-start">
                 <input
                   class="form-control w-50 fs-15px lh-15px"
@@ -185,7 +185,7 @@
                   (ngModelChange)="_updateBitCloutToBuy($event)"
                 />
                 <div class="ml-2 w-50 fs-15px">
-                  $BitClout &middot;
+                  $Clout &middot;
                   <a class="text-grey7" (click)="_clickMaxBitClout()">
                     <u>Max</u>
                   </a>

--- a/src/app/feed/feed.component.html
+++ b/src/app/feed/feed.component.html
@@ -29,7 +29,7 @@
   <countdown-timer *ngIf="isMobile" [justifyLeft]="true"></countdown-timer>
   <!-- Mobile BitClout Price -->
   <div *ngIf="isMobile" class="d-flex border-bottom border-color-grey background-color-grey py-5px px-15px fs-12px">
-    <div>$BitClout Price&nbsp;&nbsp;&nbsp;</div>
+    <div>$Clout Price&nbsp;&nbsp;&nbsp;</div>
     <div>
       ~{{ globalVars.bitcloutToUSDExchangeRateToDisplay }}
       <span class="text-muted">USD per coin</span>

--- a/src/app/landing-page/landing-page.component.html
+++ b/src/app/landing-page/landing-page.component.html
@@ -17,7 +17,7 @@
             [routerLink]="'/' + globalVars.RouteNames.BUY_BITCLOUT"
             queryParamsHandling="merge"
           >
-            Buy $BitClout
+            Buy $Clout
           </a>
         </div>
       </div>
@@ -45,7 +45,7 @@
               [routerLink]="'/' + globalVars.RouteNames.BUY_BITCLOUT"
               queryParamsHandling="merge"
             >
-              Buy $BitClout
+              Buy $Clout
             </a>
           </div>
         </div>
@@ -159,7 +159,7 @@
         <b>BitClout is not a company.</b>
         It's an open-source blockchain like Bitcoin.
         <br class="d-none d-md-block" />
-        You can own a piece by buying the $BitClout coin.
+        You can own a piece by buying the BitClout coin $Clout.
         <br />
         <br />
         <a href="https://docs.bitclout.com/the-vision" target="_blank">Learn More</a>

--- a/src/app/right-bar-creators/right-bar-creators.component.html
+++ b/src/app/right-bar-creators/right-bar-creators.component.html
@@ -11,14 +11,14 @@
   <!-- BitClout Price / Balance -->
   <div class="right-bar-creators__balance-box br-12px p-15px mb-30px fs-13px text-grey5 font-weight-bold">
     <div class="d-flex justify-content-between">
-      <div>$BitClout Price</div>
+      <div>$Clout Price</div>
       <div>
         ~{{ globalVars.bitcloutToUSDExchangeRateToDisplay }}
         <span class="text-muted">USD per coin</span>
       </div>
     </div>
     <div *ngIf="globalVars.loggedInUser" class="d-flex justify-content-between pt-10px">
-      <div class="d-flex" style="min-width: 150px">Your $BitClout</div>
+      <div class="d-flex" style="min-width: 150px">Your $Clout</div>
       <div class="d-flex align-items-center justify-content-end flex-wrap">
         <div>
           <!-- Amount in BitClout-->

--- a/src/app/sign-up/sign-up.component.html
+++ b/src/app/sign-up/sign-up.component.html
@@ -85,7 +85,7 @@
       </div>
       <div class="fs-18px pt-15px">
         <span>
-          $BitClout is a
+          BitClout is a
           <b>cryptocurrency</b>
           like Bitcoin, only it powers the first
           <b>decentralized social network</b>
@@ -99,7 +99,7 @@
       <div class="d-flex justify-content-end mt-15px pt-10px">
         <button (click)="buyBitCloutSkipped()" class="btn btn-outline-primary font-weight-bold fs-15px">Skip</button>
         <button (click)="buyBitCloutClicked()" class="btn btn-primary font-weight-bold fs-15px ml-10px">
-          Buy BitClout
+          Buy $Clout
         </button>
       </div>
     </div>

--- a/src/app/transfer-bitclout/transfer-bitclout.component.html
+++ b/src/app/transfer-bitclout/transfer-bitclout.component.html
@@ -4,14 +4,14 @@
 >
   <top-bar-mobile-navigation-control class="mr-15px d-lg-none d-inline-block"></top-bar-mobile-navigation-control>
 
-  Send $BitClout
+  Send $Clout
 </div>
 
 <!-- Explainer -->
 <div
   class="d-flex align-items-center fs-15px fc-muted p-15px border-bottom border-color-grey background-color-light-grey"
 >
-  Sending $BitClout is easy. Just enter a public key below and the protocol will handle the rest.
+  Sending $Clout is easy. Just enter a public key below and the protocol will handle the rest.
 </div>
 
 <div class="fs-15px font-weight-bold mt-15px px-15px">
@@ -23,7 +23,7 @@
   />
 </div>
 
-<div class="fs-15px font-weight-bold mt-15px px-15px">Amount of $BitClout to send:</div>
+<div class="fs-15px font-weight-bold mt-15px px-15px">Amount of $Clout to send:</div>
 <div class="d-flex align-items-center px-15px mt-5px">
   <input type="number" class="form-control w-100 fs-15px lh-15px" placeholder="0" [(ngModel)]="transferAmount" />
   <button

--- a/src/app/transfer-bitclout/transfer-bitclout.component.ts
+++ b/src/app/transfer-bitclout/transfer-bitclout.component.ts
@@ -13,9 +13,9 @@ class Messages {
   static SEND_BITCLOUT_MIN = `You must send a non-zero amount of BitClout`;
   static INVALID_PUBLIC_KEY = `The public key you entered is invalid`;
   static CONFIRM_TRANSFER_TO_PUBKEY =
-    "Send %s $BitClout with a fee of %s BitClout for a total of %s BitClout to public key %s";
+    "Send %s $Clout with a fee of %s BitClout for a total of %s BitClout to public key %s";
   static CONFIRM_TRANSFER_TO_USERNAME =
-    "Send %s $BitClout with a fee of %s BitClout for a total of %s BitClout to username %s";
+    "Send %s $Clout with a fee of %s BitClout for a total of %s BitClout to username %s";
 }
 
 @Component({
@@ -44,7 +44,7 @@ export class TransferBitcloutComponent implements OnInit {
 
   ngOnInit() {
     this.feeRateBitCloutPerKB = (this.globalVars.defaultFeeRateNanosPerKB / 1e9).toFixed(9);
-    this.titleService.setTitle("Send $BitClout - BitClout");
+    this.titleService.setTitle("Send $Clout - BitClout");
   }
 
   _clickMaxBitClout() {
@@ -85,7 +85,7 @@ export class TransferBitcloutComponent implements OnInit {
     }
 
     if (this.payToPublicKey == null || this.payToPublicKey === "") {
-      this.globalVars._alertError("A valid pay-to public key or username must be set before you can send $BitClout");
+      this.globalVars._alertError("A valid pay-to public key or username must be set before you can send $Clout");
       return;
     }
 

--- a/src/app/update-profile-page/update-profile/update-profile.component.ts
+++ b/src/app/update-profile-page/update-profile/update-profile.component.ts
@@ -202,7 +202,7 @@ export class UpdateProfileComponent implements OnInit, OnChanges {
             confirmButton: "btn btn-light",
             cancelButton: "btn btn-light no",
           },
-          confirmButtonText: lowBalance ? "Buy $Bitclout" : null,
+          confirmButtonText: lowBalance ? "Buy $Clout" : null,
           cancelButtonText: lowBalance ? "Later" : null,
           showCancelButton: lowBalance,
         }).then((res) => {

--- a/src/app/wallet/wallet.component.html
+++ b/src/app/wallet/wallet.component.html
@@ -12,11 +12,11 @@
   <div class="d-flex flex-column" *ngIf="globalVars.loggedInUser">
     <div style="flex-grow: 1">
       <div class="global__mobile-scrollable-section">
-        <!-- $BitClout Divider Bar -->
+        <!-- $Clout Divider Bar -->
         <div
           class="d-flex align-items-center justify-content-between fs-18px font-weight-bold p-15px holdings__divider border-bottom border-color-grey"
         >
-          <div>$BitClout</div>
+          <div>$Clout</div>
           <div class="fs-15px" style="margin-top: 2px">
             <a
               *ngIf="globalVars.loggedInUser"
@@ -32,7 +32,7 @@
           </div>
         </div>
 
-        <!-- $BitClout Holdings -->
+        <!-- $Clout Holdings -->
         <!-- Override .container's max-width property with max-width: inherit-->
         <div class="container fs-15px p-15px border-bottom border-color-grey" style="max-width: inherit">
           <div class="row pt-5px">


### PR DESCRIPTION
With 3 days to go to deflation, i thought it would be good to switch to $clout instead of $BitClout.

![20210609-fvhFOrEY](https://user-images.githubusercontent.com/69529928/121309885-a1fca380-c8fa-11eb-9682-f068f04ef3d5.png)

Replaced all occurrences apart from a few exceptions, like landing page header where I changed from `$BitClout` to `BitClout`.
