### PR TITLE
Fix profile avatars on notifications

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1417,6 +1417,7 @@ $green-font-color: #19B028;
    height: 28px;
    width: 28px;
    border-radius: 3px;
+   background-size: auto 100%;
 }
 
 .notifications__action {


### PR DESCRIPTION
@lazynina @tijno 

I noticed also profile avatars on profile pages will display both the default avatar and the users avatar over it if it is transparent, I can open another PR for a fix if needed?