### PR TITLE
Fix iOS Input Boxes

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1766,6 +1766,11 @@ $green-font-color: #19B028;
   color: var(--text) !important;
   background: var(--formbg) !important;
   border-color: var(--border) !important;
+  outline: none;
+  -webkit-box-shadow: none !important;
+  -moz-box-shadow: none !important;
+  box-shadow: none !important;
+  background-clip: padding-box;
 }
 .normal-text {
   color: $text-color;


### PR DESCRIPTION
This fixes the iOS input boxes. Basically resolves a bug with bootstrap CSS and inputs on iOS mobile (removes the top border by clipping)

@lazynina 