### PR TITLE
Save new users a lot of pain from rug pullers

### DIFF
--- a/src/app/update-profile-page/update-profile/update-profile.component.ts
+++ b/src/app/update-profile-page/update-profile/update-profile.component.ts
@@ -77,14 +77,14 @@ export class UpdateProfileComponent implements OnInit, OnChanges {
 
   founderRewardTooltip() {
     return (
-      "When someone purchases your coin, a percentage of each coin purchase " +
-      "gets allocated to you as a founder reward.\n\n" +
-      "A value of 0% means that no new coins get allocated to you when someone buys, " +
-      "whereas a value of 100% means that nobody other than you can ever get coins because 100% of " +
-      "every purchase will just go to you.\n\n" +
-      "Setting this value too high will deter buyers from ever " +
-      "purchasing your coin. It's a balance, so be careful or just stick " +
-      "with the default."
+      "When someone purchases your coin, a percentage " +
+      "is allocated to you as a 'founder reward'.\n\n" +
+      "A value of 0% means no value gets rewarded to you for each coin purchased, " +
+      "whereas a value of 100% means no one other than you gets the value because 100% " +
+      "goes to you.\n\nSetting it too high will deter others from " +
+      "buying your coin. Setting it too low risks 'rug-pullers' profitting off of " +
+      "your hard work. It's a balance, so be careful. After you've bought what you'd " +
+      "like of your own coin, consider setting this value to 10-20%."
     );
   }
 
@@ -170,7 +170,7 @@ export class UpdateProfileComponent implements OnInit, OnChanges {
       this.profileUpdates.usernameUpdate /*NewUsername*/,
       this.profileUpdates.descriptionUpdate /*NewDescription*/,
       this.profileUpdates.profilePicUpdate /*NewProfilePic*/,
-      this.founderRewardInput * 100 /*NewCreatorBasisPoints*/,
+      this.founderRewardInput * 1000 /*NewCreatorBasisPoints*/,
       1.25 * 100 * 100 /*NewStakeMultipleBasisPoints*/,
       false /*IsHidden*/,
       // End params


### PR DESCRIPTION
At onboarding, users are excited to get started, but the first thing they HAVE to do is update their profile. 
The initial FR should not be anything other than 100% at this point in the process!

If changed from 100% at this first opportunity, scammers using auto-bots quickly purchase before users are able to buy their coin.
Before they know it, upon trying to take their 2nd action, their coin price has increased and any $ they put in goes directly into the hands of the owners of the bots.

This 1 change is a must imho to improve the user experience of new clouters.