### PR TITLE
switch creator button to link to trends

### DIFF
--- a/src/app/bottom-bar-mobile/bottom-bar-mobile.component.html
+++ b/src/app/bottom-bar-mobile/bottom-bar-mobile.component.html
@@ -12,7 +12,7 @@
       <i class="icon-wallet fs-25px"></i>
     </bottom-bar-mobile-tab>
 
-    <bottom-bar-mobile-tab class="w-100 h-100 text-center" [link]="'/' + globalVars.RouteNames.CREATORS">
+    <bottom-bar-mobile-tab class="w-100 h-100 text-center" [link]="'/' + globalVars.RouteNames.TRENDS">
       <i class="icon-up-arrow fs-25px"></i>
     </bottom-bar-mobile-tab>
 


### PR DESCRIPTION
@lazynina the bottom bar on mobile still links to the old `CREATORS` route. This change links it to the new amazing `TRENDS` route that you deployed today e383f76254f2543551cd2df0fa3bf562a1f39061.

