### PR TITLE
Adds following count and link to creator-profile-top-card

### DIFF
--- a/src/app/creator-profile-page/creator-profile-top-card/creator-profile-top-card.component.html
+++ b/src/app/creator-profile-page/creator-profile-top-card/creator-profile-top-card.component.html
@@ -110,6 +110,16 @@
         <span class="fc-muted">Followers&nbsp;&nbsp;</span>
       </a>
 
+      <a
+        class="link--unstyled"
+        *ngIf="followingCount != null"
+        [routerLink]="AppRoutingModule.userFollowingPath(profile.Username)"
+        queryParamsHandling="merge"
+      >
+        <span class="font-weight-bold">{{ followingCount }}&nbsp;</span>
+        <span class="fc-muted">Following&nbsp;&nbsp;</span>
+      </a>
+
       <div style="whitespace: nowrap">
         <div class="font-weight-bold" style="display: inline">
           ~{{ globalVars.nanosToUSD(profile.CoinPriceBitCloutNanos, 2) }}


### PR DESCRIPTION
Adds the user's following count to Creator Profile top cards.

This is a feature of [BitClout+](https://github.com/iPaulPro/BitCloutPlus) and something that users have praised for allowing them to quickly determine if an account is likely fraudulent or a bot.

<img src="https://user-images.githubusercontent.com/354227/121901963-e326f600-ccf4-11eb-87f3-ff388d927131.jpg" width="400px" />

I've set the `NumToFetch` to `0` for the call to `GetFollows` in hopes that perhaps it will be updated to exclude the `PublicKeyToProfileEntry` object. Right now it returns one profile when set to 0.