### PR TITLE
Blacklisted profile fixes

### DIFF
--- a/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.ts
+++ b/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.ts
@@ -171,6 +171,11 @@ export class CreatorProfileDetailsComponent {
           this.loading = false;
           return;
         }
+        if (res.IsBlacklisted) {
+          this.loading = false;
+          this.router.navigateByUrl("/" + this.appData.RouteNames.NOT_FOUND, { skipLocationChange: true });
+          return;
+        }
         this.profile = res.Profile;
         this.loading = false;
       },

--- a/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.ts
+++ b/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.ts
@@ -166,12 +166,7 @@ export class CreatorProfileDetailsComponent {
     this.loading = true;
     this.backendApi.GetSingleProfile(this.globalVars.localNode, "", this.userName).subscribe(
       (res) => {
-        if (!res) {
-          console.log("This profile was not found. It either does not exist or it was deleted.");
-          this.loading = false;
-          return;
-        }
-        if (res.IsBlacklisted) {
+        if (!res || res.IsBlacklisted) {
           this.loading = false;
           this.router.navigateByUrl("/" + this.appData.RouteNames.NOT_FOUND, { skipLocationChange: true });
           return;


### PR DESCRIPTION
if user is blacklisted, we redirect to not found page in creator profile details component.
- Updated get-single-profile to return the blacklist and graylist status so we don't have to update the trade-creator component to support selling blacklisted creators.