### PR TITLE
Drag and Drop Image Uploads

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -116,6 +116,7 @@ import { CountdownTimerComponent } from "./countdown-timer/countdown-timer.compo
 import { AvatarDirective } from "./avatar/avatar.directive";
 import { TrendsPageComponent } from "./trends-page/trends-page.component";
 import { TrendsComponent } from "./trends-page/trends/trends.component";
+import { UploadDirective } from "./directives/upload.directive";
 
 // Modular Themes for BitClout by Carsen Klock @carsenk
 import { ThemeModule } from "./theme/theme.module";
@@ -127,6 +128,7 @@ import { legendsTheme } from "./theme/legends-theme";
 @NgModule({
   declarations: [
     AppComponent,
+    UploadDirective,
     TermsOfServiceComponent,
     ManageFollowsComponent,
     ManageFollowsPageComponent,

--- a/src/app/directives/upload.directive.spec.ts
+++ b/src/app/directives/upload.directive.spec.ts
@@ -1,0 +1,8 @@
+import { UploadDirective } from "./upload.directive";
+
+describe("UploadDirective", () => {
+  it("should create an instance", () => {
+    const directive = new UploadDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/directives/upload.directive.ts
+++ b/src/app/directives/upload.directive.ts
@@ -7,14 +7,12 @@ export class UploadDirective {
   @Output() onFileDropped = new EventEmitter<any>();
   @HostBinding("style.opacity") public opacity = "1";
 
-  //Dragover listener, when something is dragged over our host element
   @HostListener("dragover", ["$event"]) onDragOver(evt) {
     evt.preventDefault();
     evt.stopPropagation();
     this.opacity = "0.5";
   }
 
-  //Dragleave listener, when something is dragged away from our host element
   @HostListener("dragleave", ["$event"]) public onDragLeave(evt) {
     evt.preventDefault();
     evt.stopPropagation();

--- a/src/app/directives/upload.directive.ts
+++ b/src/app/directives/upload.directive.ts
@@ -1,0 +1,35 @@
+import { Directive, Output, EventEmitter, HostBinding, HostListener, HostBindingDecorator } from "@angular/core";
+
+@Directive({
+  selector: "[dropUpload]",
+})
+export class UploadDirective {
+  @Output() onFileDropped = new EventEmitter<any>();
+  @HostBinding("style.opacity") public opacity = "1";
+
+  //Dragover listener, when something is dragged over our host element
+  @HostListener("dragover", ["$event"]) onDragOver(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    this.opacity = "0.5";
+  }
+
+  //Dragleave listener, when something is dragged away from our host element
+  @HostListener("dragleave", ["$event"]) public onDragLeave(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    this.opacity = "1";
+  }
+
+  @HostListener("drop", ["$event"]) public ondrop(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    this.opacity = "1";
+    let files = evt.dataTransfer.files;
+    if (files.length > 0) {
+      this.onFileDropped.emit(files);
+    }
+  }
+
+  constructor() {}
+}

--- a/src/app/feed/feed-create-post/feed-create-post.component.html
+++ b/src/app/feed/feed-create-post/feed-create-post.component.html
@@ -31,6 +31,8 @@
         class="form-control fs-18px m-5px p-0 border-0 feed-create-post__textarea"
         [placeholder]="getPlaceholderText()"
         (paste)="onPaste($event)"
+        dropUpload
+        (onFileDropped)="uploadFile($event)"
         cdkTextareaAutosize
         #autosize="cdkTextareaAutosize"
       ></textarea>

--- a/src/app/feed/feed-create-post/feed-create-post.component.ts
+++ b/src/app/feed/feed-create-post/feed-create-post.component.ts
@@ -86,6 +86,12 @@ export class FeedCreatePostComponent implements OnInit {
     }
   }
 
+  uploadFile(event: any): void {
+    console.log("Dropped Image");
+
+    this._handleFileInput(event[0]);
+  }
+
   showCharacterCountIsFine() {
     return this.postInput.length < FeedCreatePostComponent.SHOW_POST_LENGTH_WARNING_THRESHOLD;
   }

--- a/src/app/feed/feed-create-post/feed-create-post.component.ts
+++ b/src/app/feed/feed-create-post/feed-create-post.component.ts
@@ -87,9 +87,9 @@ export class FeedCreatePostComponent implements OnInit {
   }
 
   uploadFile(event: any): void {
-    console.log("Dropped Image");
-
-    this._handleFileInput(event[0]);
+    if (!this.isComment) {
+      this._handleFileInput(event[0]);
+    }
   }
 
   showCharacterCountIsFine() {


### PR DESCRIPTION
This adds in support for drag and drag in the textarea for posting on BitClout

It follows the current file upload rules and uses the same functionality as copy/paste or selecting the file regularly.

Preview:
![e3256257bf](https://user-images.githubusercontent.com/10162347/122651605-2cad8180-d0f7-11eb-863c-7d94ea7ee41c.gif)

Follow me! https://bitclout.com/u/carsenk

https://bitclout.com/posts/8ab9370e55db4a1d00a63e6a9688f1e5237275e7a4f8d07a005948535df1736d