### PR TITLE
show different treatment for creator coins for unclaimed reserved profiles

### DIFF
--- a/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.html
+++ b/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.html
@@ -29,8 +29,14 @@
               Received
             </div>
             <div *ngIf="row.HasPurchased" class="text-grey9" style="font-size: 10px">
-              <i class="fas fa-check-square pr-5px"></i>
-              Purchased
+              <div *ngIf="row.HODLerPublicKeyBase58Check === profile.PublicKeyBase58Check && row.ProfileEntryResponse.IsReserved && !row.ProfileEntryResponse.IsVerified; else purchasedCoins">
+                <i class="far fa-clock fa-md pr-5px font-weight-bold"></i>
+                Reserved
+              </div>
+              <ng-template #purchasedCoins>
+                <i class="fas fa-check-square pr-5px"></i>
+                Purchased
+              </ng-template>
             </div>
           </div>
         </div>
@@ -80,8 +86,14 @@
               Received
             </div>
             <div *ngIf="row.HasPurchased" class="text-grey9" style="font-size: 10px">
-              <i class="fas fa-check-square pr-5px"></i>
-              Purchased
+              <div *ngIf="row.HODLerPublicKeyBase58Check === profile.PublicKeyBase58Check && row.ProfileEntryResponse.IsReserved && !row.ProfileEntryResponse.IsVerified; else purchasedCoins">
+                <i class="far fa-clock fa-md pr-5px font-weight-bold"></i>
+                Reserved
+              </div>
+              <ng-template #purchasedCoins>
+                <i class="fas fa-check-square pr-5px"></i>
+                Purchased
+              </ng-template>
             </div>
           </div>
         </div>

--- a/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.ts
+++ b/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.ts
@@ -133,6 +133,13 @@ export class CreatorProfileHodlersComponent {
   }
 
   getTooltipForRow(row: BalanceEntryResponse): string {
+    if (
+      row.HODLerPublicKeyBase58Check === this.profile.PublicKeyBase58Check &&
+      row.ProfileEntryResponse.IsReserved &&
+      !row.ProfileEntryResponse.IsVerified
+    ) {
+      return `These creator coins are reserved for ${this.profile.Username}`;
+    }
     return row.HasPurchased
       ? `This user has purchased some amount of $${this.profile.Username} coin.`
       : `This user has not purchased $${this.profile.Username} coin.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/81658138/123352464-2f9fdc00-d514-11eb-840e-dc1bad504fed.png)

- use different copy when hovering over "reserved" creator coins
- show reserved clock icon and use text "Reserved" when displaying creator coins in reserved profile