### PR TITLE
Changed BitClout to $CLOUT in notifications

### DIFF
--- a/src/app/notifications-page/notifications-list/notifications-list.component.ts
+++ b/src/app/notifications-page/notifications-list/notifications-list.component.ts
@@ -189,7 +189,7 @@ export class NotificationsListComponent implements OnInit {
       }
       result.icon = "fas fa-money-bill-wave-alt fc-green";
       result.action = `${actorName} sent you ${this.globalVars.nanosToBitClout(txnAmountNanos)} ` +
-        `BitClout!</b> (~${this.globalVars.nanosToUSD(txnAmountNanos, 2)})`;
+        `$CLOUT!</b> (~${this.globalVars.nanosToUSD(txnAmountNanos, 2)})`;
       return result;
     } else if (txnMeta.TxnType === "CREATOR_COIN") {
       // If we don't have the corresponding metadata then return null.


### PR DESCRIPTION
Earlier: "XYZ sent you 1.5 BitClout! (~$140)"

Now: "XYZ sent you 1.5 $CLOUT! (~$140)"
![Screenshot from 2021-06-26 13-09-46](https://user-images.githubusercontent.com/55331140/123506058-e10f5080-d67f-11eb-8a1b-ee2f5c51fbbc.png)
