### PR TITLE
show user to whom you are sending clout on the send-bitclout page

### DIFF
--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -646,7 +646,7 @@ export class GlobalVarsService {
   // Does some basic checks on a public key.
   isMaybePublicKey(pk: string) {
     // Test net public keys start with 'tBC', regular public keys start with 'BC'.
-    return pk.startsWith("tBC") || pk.startsWith("BC");
+    return (pk.startsWith("tBC") && pk.length == 54) || (pk.startsWith("BC") && pk.length == 55);
   }
 
   isVanillaReclout(post: PostEntryResponse): boolean {

--- a/src/app/messages-page/messages-thread-view/messages-thread-view.component.html
+++ b/src/app/messages-page/messages-thread-view/messages-thread-view.component.html
@@ -3,6 +3,7 @@
   <div
     *ngIf="!isMobile"
     class="w-100 global__top-bar__height d-flex align-items-center pl-15px fs-15px font-weight-bold border-bottom border-color-grey"
+    style="min-height: 80px;"
   >
     <!-- Avatar -->
     <!-- This should only link if the user has a profile (i.e. if it's just a pubkey, no link) -->

--- a/src/app/search-bar/search-bar.component.html
+++ b/src/app/search-bar/search-bar.component.html
@@ -8,7 +8,13 @@
   <div class="d-flex align-items-center w-100 text-grey8A fs-15px global__top-bar__height">
     <div class="input-group">
       <div class="input-group-prepend">
-        <span class="input-group-text search-bar__icon">
+        <span
+          class="input-group-text search-bar__icon"
+          [ngStyle]="{
+          'border-top-left-radius': isSearchForUsersToSendClout ? '0.25rem' : '',
+          'border-bottom-left-radius': isSearchForUsersToSendClout ? '0.25rem' : ''
+          }"
+        >
           <i class="icon-search"></i>
         </span>
       </div>
@@ -20,9 +26,9 @@
         (keyup.enter)="_handleCreatorSelect(creators[selectedCreatorIndex])"
         (keyup.escape)="_exitSearch()"
         type="text"
-        class="form-control shadow-none search-bar__fix-active br-12px"
-        style="border-radius: 3px"
+        class="form-control shadow-none search-bar__fix-active"
         style="font-size: 15px; padding-left: 0; border-left-color: rgba(0, 0, 0, 0)"
+        [ngClass]="{ 'br-12px': !isSearchForUsersToSendClout }"
         placeholder="Search"
       />
     </div>
@@ -41,7 +47,7 @@
       >
         <div class="search-bar__avatar m-10px" [avatar]="creator.PublicKeyBase58Check"></div>
         <div>
-          <span>{{ creator.Username }}</span>
+          <span>{{ creator.Username || creator.PublicKeyBase58Check }}</span>
           <span
             *ngIf="creator.IsReserved && !creator.IsVerified"
             class="d-inline-block ml-1 cursor-pointer lh-12px fc-muted"
@@ -60,9 +66,9 @@
           >
             <i class="fas fa-check-circle fa-md align-middle"></i>
           </span>
-          <span>&nbsp;&middot;&nbsp;</span>
+          <span *ngIf="creator.CoinPriceBitCloutNanos">&nbsp;&middot;&nbsp;</span>
         </div>
-        <div class="fc-muted">~{{ globalVars.nanosToUSD(creator.CoinPriceBitCloutNanos, 2) }}</div>
+        <div class="fc-muted" *ngIf="creator.CoinPriceBitCloutNanos">~{{ globalVars.nanosToUSD(creator.CoinPriceBitCloutNanos, 2) }}</div>
       </div>
     </div>
   </div>

--- a/src/app/search-bar/search-bar.component.ts
+++ b/src/app/search-bar/search-bar.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Renderer2, ViewChild, ElementRef, Input, Output, EventEmitter } from "@angular/core";
 import { GlobalVarsService } from "../global-vars.service";
 import { ActivatedRoute, Router } from "@angular/router";
-import { BackendApiService } from "../backend-api.service";
+import { BackendApiService, ProfileEntryResponse } from "../backend-api.service";
 import * as _ from "lodash";
 
 const DEBOUNCE_TIME_MS = 300;
@@ -11,12 +11,14 @@ const DEBOUNCE_TIME_MS = 300;
   templateUrl: "./search-bar.component.html",
   styleUrls: ["./search-bar.component.scss"],
 })
-export class SearchBarComponent {
+export class SearchBarComponent implements OnInit {
   @ViewChild("searchBarRoot", { static: true }) searchBarRoot: ElementRef;
   @Input() isSearchForUsersToMessage: boolean;
+  @Input() isSearchForUsersToSendClout: boolean;
+  @Input() startingSearchText: string;
   @Output() creatorToMessage = new EventEmitter<any>();
   searchText: string;
-  creators = [];
+  creators: ProfileEntryResponse[] = [];
   loading: boolean;
   selectedCreatorIndex: number;
   creatorSelected: string;
@@ -37,6 +39,13 @@ export class SearchBarComponent {
     this.debouncedSearchFunction = _.debounce(this._searchUsernamePrefix.bind(this), DEBOUNCE_TIME_MS);
   }
 
+  ngOnInit() {
+    if (this.startingSearchText) {
+      this.searchText = this.startingSearchText;
+      this._searchUsernamePrefix().add(() => (this.startingSearchText = ""));
+    }
+  }
+
   _searchUsernamePrefix() {
     // store the search text for the upcoming API call
     let requestedSearchText = this.searchText;
@@ -45,7 +54,44 @@ export class SearchBarComponent {
       readerPubKey = this.globalVars.loggedInUser.PublicKeyBase58Check;
     }
 
-    this.backendApi
+    // If we are searching for a public key, call get single profile with the public key.
+    if (
+      (requestedSearchText.startsWith("BC") && requestedSearchText.length == 55) ||
+      (requestedSearchText.startsWith("tBC") && requestedSearchText.length == 54)
+    ) {
+      return this.backendApi.GetSingleProfile(this.globalVars.localNode, requestedSearchText, "").subscribe(
+        (res) => {
+          if (requestedSearchText === this.searchText || requestedSearchText === this.startingSearchText) {
+            this.loading = false;
+            if (res.IsBlacklisted) {
+              return;
+            }
+            this.creators = [res.Profile];
+            if (this.startingSearchText) {
+              // If starting search text is set, we handle the selection of the creator.
+              this._handleCreatorSelect(res.Profile);
+            }
+          }
+        },
+        (err) => {
+          if (requestedSearchText === this.searchText || requestedSearchText === this.startingSearchText) {
+            this.loading = false;
+            // a 404 occurs for anonymous public keys.
+            if (err.status === 404 && this.startingSearchText) {
+              const anonProfile = { PublicKeyBase58Check: requestedSearchText, Username: "", Description: "" };
+              this.creators = [anonProfile];
+              // If starting search text is set, we handle the selection of the creator.
+              this._handleCreatorSelect(anonProfile);
+              return;
+            }
+          }
+          console.error(err);
+          this.globalVars._alertError("Error loading profiles: " + this.backendApi.stringifyError(err));
+        }
+      );
+    }
+
+    return this.backendApi
       .GetProfiles(
         this.globalVars.localNode,
         "" /*PublicKeyBase58Check*/,
@@ -63,15 +109,19 @@ export class SearchBarComponent {
         (response) => {
           // only process this response if it came from
           // the request for the current search text
-          if (requestedSearchText === this.searchText) {
+          if (requestedSearchText === this.searchText || requestedSearchText === this.startingSearchText) {
             this.loading = false;
             this.creators = response.ProfilesFound;
+            // If starting search text is set, we handle the selection of the creator.
+            if (this.startingSearchText && response.ProfilesFound.length) {
+              this._handleCreatorSelect(response.ProfilesFound[0]);
+            }
           }
         },
         (err) => {
           // only process this response if it came from
           // the request for the current search text
-          if (requestedSearchText === this.searchText) {
+          if (requestedSearchText === this.searchText || requestedSearchText === this.startingSearchText) {
             this.loading = false;
           }
           console.error(err);
@@ -104,7 +154,7 @@ export class SearchBarComponent {
   // used for finding users to message.  We handle both cases here.
   _handleCreatorSelect(creator: any) {
     if (creator && creator != "") {
-      if (this.isSearchForUsersToMessage) {
+      if (this.isSearchForUsersToMessage || this.isSearchForUsersToSendClout) {
         this.creatorToMessage.emit(creator);
       } else {
         this.router.navigate(["/" + this.globalVars.RouteNames.USER_PREFIX, creator.Username], {
@@ -117,9 +167,13 @@ export class SearchBarComponent {
       // this user should be redirected to the profile page of the user with the username
       // equal to that of the current searchText.
       if (this.searchText !== "" && !this.isSearchForUsersToMessage) {
-        this.router.navigate(["/" + this.globalVars.RouteNames.USER_PREFIX, this.searchText], {
-          queryParamsHandling: "merge",
-        });
+        if (this.isSearchForUsersToSendClout) {
+          this.creatorToMessage.emit(this.creators[0]);
+        } else {
+          this.router.navigate(["/" + this.globalVars.RouteNames.USER_PREFIX, this.searchText], {
+            queryParamsHandling: "merge",
+          });
+        }
         this._exitSearch();
       }
     }

--- a/src/app/search-bar/search-bar.component.ts
+++ b/src/app/search-bar/search-bar.component.ts
@@ -55,10 +55,7 @@ export class SearchBarComponent implements OnInit {
     }
 
     // If we are searching for a public key, call get single profile with the public key.
-    if (
-      (requestedSearchText.startsWith("BC") && requestedSearchText.length == 55) ||
-      (requestedSearchText.startsWith("tBC") && requestedSearchText.length == 54)
-    ) {
+    if (this.globalVars.isMaybePublicKey(requestedSearchText)) {
       return this.backendApi.GetSingleProfile(this.globalVars.localNode, requestedSearchText, "").subscribe(
         (res) => {
           if (requestedSearchText === this.searchText || requestedSearchText === this.startingSearchText) {

--- a/src/app/simple-profile-card/simple-profile-card.component.html
+++ b/src/app/simple-profile-card/simple-profile-card.component.html
@@ -1,9 +1,10 @@
 <a
-  class="container d-flex align-items-center fs-15px p-10px border-bottom border-color-grey link--unstyled"
+  class="container d-flex align-items-center fs-15px p-10px border-color-grey link--unstyled"
+  [ngClass]="{ 'border-bottom': !singleColumn }"
   (click)="onClick()"
 >
   <div class="row no-gutters w-100">
-    <div class="col-6 d-flex align-items-center" style="margin-bottom: 0px">
+    <div class="d-flex align-items-center mb-0" [ngClass]="{ 'col-6': !singleColumn }">
       <!-- Avatar -->
       <div class="simple-profile-card__avatar-container">
         <div
@@ -12,8 +13,8 @@
         ></div>
       </div>
       <div class="text-truncate holdings__name fs-15px">
-        <div>
-          <a class="fc-default font-weight-bold">{{ profile.Username }}</a>
+        <div class="d-flex">
+          <div class="fc-default font-weight-bold text-truncate holdings__name link--unstyled">{{ profile.Username || profile.PublicKeyBase58Check }}</div>
           <span
             *ngIf="profile.IsVerified"
             (click)="tooltip.toggle()"
@@ -25,13 +26,13 @@
             <i class="fas fa-check-circle fa-md align-middle"></i>
           </span>
         </div>
-        <div class="text-grey9">
+        <div class="text-grey9" *ngIf="profile.CoinPriceBitCloutNanos">
           {{ globalVars.nanosToUSD(profile.CoinPriceBitCloutNanos, 2) }}
         </div>
       </div>
     </div>
 
-    <div class="col-6 d-flex align-items-center justify-content-center" style="margin-bottom: 0px">
+    <div class="col-6 d-flex align-items-center justify-content-center mb-0">
       <div *ngIf="diamondLevel > 0" class="d-flex">
         <i *ngFor="let diamond of counter(diamondLevel)" class="icon-diamond fs-20px d-block"></i>
       </div>

--- a/src/app/simple-profile-card/simple-profile-card.component.ts
+++ b/src/app/simple-profile-card/simple-profile-card.component.ts
@@ -12,6 +12,7 @@ export class SimpleProfileCardComponent implements OnInit {
   @Input() showHeartIcon = false;
   @Input() showRecloutIcon = false;
   @Input() containerModalRef: any = null;
+  @Input() singleColumn = false;
 
   constructor(public globalVars: GlobalVarsService, private router: Router) {}
 

--- a/src/app/transfer-bitclout/transfer-bitclout.component.html
+++ b/src/app/transfer-bitclout/transfer-bitclout.component.html
@@ -16,11 +16,16 @@
 
 <div class="fs-15px font-weight-bold mt-15px px-15px">
   Public key or username to pay:
-  <input
-    class="form-control w-100 fs-15px lh-15px mt-5px"
-    placeholder="Enter a public key or username."
-    [(ngModel)]="payToPublicKey"
-  />
+  <!-- Search Bar -->
+  <search-bar
+    [startingSearchText]="startingSearchText"
+    [isSearchForUsersToSendClout]="true"
+    (creatorToMessage)="_handleCreatorSelectedInSearch($event)"
+  ></search-bar>
+</div>
+
+<div class="px-5px">
+  <simple-profile-card [profile]="payToCreator" [singleColumn]="true" *ngIf="payToCreator"></simple-profile-card>
 </div>
 
 <div class="fs-15px font-weight-bold mt-15px px-15px">Amount of $CLOUT to send:</div>

--- a/src/app/transfer-bitclout/transfer-bitclout.component.ts
+++ b/src/app/transfer-bitclout/transfer-bitclout.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from "@angular/core";
-import { BackendApiService } from "../backend-api.service";
+import { BackendApiService, ProfileEntryResponse } from "../backend-api.service";
 import { GlobalVarsService } from "../global-vars.service";
 import { sprintf } from "sprintf-js";
 import { SwalHelper } from "../../lib/helpers/swal-helper";
@@ -28,7 +28,9 @@ class Messages {
 export class TransferBitcloutComponent implements OnInit {
   globalVars: GlobalVarsService;
   transferBitCloutError = "";
+  startingSearchText = "";
   payToPublicKey = "";
+  payToCreator: ProfileEntryResponse;
   transferAmount = 0;
   networkFee = 0;
   feeRateBitCloutPerKB: string;
@@ -47,7 +49,7 @@ export class TransferBitcloutComponent implements OnInit {
     this.globalVars = globalVarsService;
     this.route.queryParams.subscribe((queryParams) => {
       if (queryParams.public_key) {
-        this.payToPublicKey = queryParams.public_key;
+        this.startingSearchText = queryParams.public_key;
       }
     });
   }
@@ -310,5 +312,10 @@ export class TransferBitcloutComponent implements OnInit {
     // If we get here we have no idea what went wrong so just alert the
     // errorString.
     return JSON.stringify(err);
+  }
+
+  _handleCreatorSelectedInSearch(creator: ProfileEntryResponse) {
+    this.payToCreator = creator;
+    this.payToPublicKey = creator?.Username || creator?.PublicKeyBase58Check || "";
   }
 }


### PR DESCRIPTION
Use search-bar component to get username and avatar when searching for user on Send BitClout page.

![image](https://user-images.githubusercontent.com/81658138/123570157-7ee84580-d77c-11eb-9579-48d875ee1dc0.png)

![image](https://user-images.githubusercontent.com/81658138/123570182-90315200-d77c-11eb-89f5-1eab871c9e81.png)

Updated search bar component to search for single profile based on public key if search text looks like a public key.

Supports public keys with a profile:
![image](https://user-images.githubusercontent.com/81658138/123570352-e1414600-d77c-11eb-9fa9-ab80fd2e5e66.png)

