### PR TITLE
Fix alignment of simple profile card icons 

### DIFF
--- a/src/app/simple-profile-card/simple-profile-card.component.html
+++ b/src/app/simple-profile-card/simple-profile-card.component.html
@@ -1,29 +1,19 @@
-<a
-  class="container d-flex align-items-center fs-15px p-10px border-color-grey link--unstyled"
-  [ngClass]="{ 'border-bottom': !singleColumn }"
-  [ngStyle]="{ 'cursor': !profile.Username ? 'default' : '' }"
-  (click)="onClick()"
->
+<a class="container d-flex align-items-center fs-15px p-10px border-color-grey link--unstyled"
+  [ngClass]="{ 'border-bottom': !singleColumn }" [ngStyle]="{ 'cursor': !profile.Username ? 'default' : '' }"
+  (click)="onClick()">
   <div class="row no-gutters w-100">
-    <div class="d-flex align-items-center mb-0" [ngClass]="{ 'col-6': !singleColumn }">
+    <div class="d-flex align-items-center mb-0 flex-grow-1">
       <!-- Avatar -->
       <div class="simple-profile-card__avatar-container">
-        <div
-          class="simple-profile-card__avatar br-12px"
-          [avatar]="profile.PublicKeyBase58Check"
-        ></div>
+        <div class="simple-profile-card__avatar br-12px" [avatar]="profile.PublicKeyBase58Check"></div>
       </div>
       <div class="text-truncate holdings__name fs-15px">
         <div class="d-flex">
-          <div class="fc-default font-weight-bold text-truncate holdings__name link--unstyled">{{ profile.Username || profile.PublicKeyBase58Check }}</div>
-          <span
-            *ngIf="profile.IsVerified"
-            (click)="tooltip.toggle()"
-            class="ml-1 mb-1 cursor-pointer text-primary"
+          <div class="fc-default font-weight-bold text-truncate holdings__name link--unstyled">{{ profile.Username ||
+            profile.PublicKeyBase58Check }}</div>
+          <span *ngIf="profile.IsVerified" (click)="tooltip.toggle()" class="ml-1 mb-1 cursor-pointer text-primary"
             matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
-            [matTooltip]="'This account is verified'"
-            #tooltip="matTooltip"
-          >
+            [matTooltip]="'This account is verified'" #tooltip="matTooltip">
             <i class="fas fa-check-circle fa-md align-middle"></i>
           </span>
         </div>
@@ -33,7 +23,7 @@
       </div>
     </div>
 
-    <div class="col-6 d-flex align-items-center justify-content-center mb-0">
+    <div class="d-flex align-items-center justify-content-center mb-0">
       <div *ngIf="diamondLevel > 0" class="d-flex">
         <i *ngFor="let diamond of counter(diamondLevel)" class="icon-diamond fs-20px d-block"></i>
       </div>

--- a/src/app/simple-profile-card/simple-profile-card.component.html
+++ b/src/app/simple-profile-card/simple-profile-card.component.html
@@ -1,19 +1,29 @@
-<a class="container d-flex align-items-center fs-15px p-10px border-color-grey link--unstyled"
-  [ngClass]="{ 'border-bottom': !singleColumn }" [ngStyle]="{ 'cursor': !profile.Username ? 'default' : '' }"
-  (click)="onClick()">
+<a
+  class="container d-flex align-items-center fs-15px p-10px border-color-grey link--unstyled"
+  [ngClass]="{ 'border-bottom': !singleColumn }"
+  [ngStyle]="{ 'cursor': !profile.Username ? 'default' : '' }"
+  (click)="onClick()"
+>
   <div class="row no-gutters w-100">
-    <div class="d-flex align-items-center mb-0 flex-grow-1">
+    <div class="d-flex flex-grow-1 align-items-center mb-0">
       <!-- Avatar -->
       <div class="simple-profile-card__avatar-container">
-        <div class="simple-profile-card__avatar br-12px" [avatar]="profile.PublicKeyBase58Check"></div>
+        <div
+          class="simple-profile-card__avatar br-12px"
+          [avatar]="profile.PublicKeyBase58Check"
+        ></div>
       </div>
       <div class="text-truncate holdings__name fs-15px">
         <div class="d-flex">
-          <div class="fc-default font-weight-bold text-truncate holdings__name link--unstyled">{{ profile.Username ||
-            profile.PublicKeyBase58Check }}</div>
-          <span *ngIf="profile.IsVerified" (click)="tooltip.toggle()" class="ml-1 mb-1 cursor-pointer text-primary"
+          <div class="fc-default font-weight-bold text-truncate holdings__name link--unstyled">{{ profile.Username || profile.PublicKeyBase58Check }}</div>
+          <span
+            *ngIf="profile.IsVerified"
+            (click)="tooltip.toggle()"
+            class="ml-1 mb-1 cursor-pointer text-primary"
             matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
-            [matTooltip]="'This account is verified'" #tooltip="matTooltip">
+            [matTooltip]="'This account is verified'"
+            #tooltip="matTooltip"
+          >
             <i class="fas fa-check-circle fa-md align-middle"></i>
           </span>
         </div>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1693,10 +1693,9 @@ $green-font-color: #19B028;
 }
 
 .simple-profile-card__avatar-container {
-  width: 56px; // TODO: figure out why chrome doesn't render this as 50px
+  width: 50px; 
   margin-right: 15px;
 }
-
 
 //
 // (end) v0 styles


### PR DESCRIPTION
_Hello! I am new here. Please let me know if there's anything I should change about this PR. It's my very first (to an open source project). It's my warm-up to make sure I'm doing things properly 🙂_

## Description
Addresses style nit and fixes alignment of heart/diamond/reclout icon on simple profile card.

## Screenshots
Before | After
-|-
<img width="544" alt="Screen Shot 2021-07-06 at 5 55 38 PM" src="https://user-images.githubusercontent.com/6456722/124671617-bee9af80-de83-11eb-9873-78136ad990fa.png"> | <img width="556" alt="Screen Shot 2021-07-06 at 5 55 18 PM" src="https://user-images.githubusercontent.com/6456722/124671622-c0b37300-de83-11eb-9fe1-b7267c677b70.png">
<img width="536" alt="Screen Shot 2021-07-06 at 5 55 42 PM" src="https://user-images.githubusercontent.com/6456722/124671633-c4df9080-de83-11eb-8338-54ea35055740.png"> | <img width="550" alt="Screen Shot 2021-07-06 at 5 55 23 PM" src="https://user-images.githubusercontent.com/6456722/124671637-c610bd80-de83-11eb-9acf-fccc6da71f37.png">



### As for the transfer page...
<img width="850" alt="after" src="https://user-images.githubusercontent.com/6456722/124671608-babd9200-de83-11eb-9970-b0fc30850c93.png">

### And the width of the profile card...
<img width="550" alt="width" src="https://user-images.githubusercontent.com/6456722/124671906-2f90cc00-de84-11eb-9d95-f59df67b6c2b.png">



