### PR TITLE
Fix account switcher dropdown not closing when on browse page

### DIFF
--- a/src/app/change-account-selector/change-account-selector.component.ts
+++ b/src/app/change-account-selector/change-account-selector.component.ts
@@ -52,7 +52,9 @@ export class ChangeAccountSelectorComponent {
 
   // TODO: Cleanup - we should consider using a dropdown library that does all this hard work for us
   _setUpClickListener() {
+    let touched = false;
     this.renderer.listen("window", "touchstart", (e: any) => {
+      touched = true;
       if (e.touches.length > 0 && e.touches[0].target.offsetParent) {
         if (e.touches[0].target.offsetParent === this.accountSelectorRoot.nativeElement) {
           if (!this.selectorOpen) {
@@ -71,19 +73,21 @@ export class ChangeAccountSelectorComponent {
         }
       }
       // If we get here, the user did not click the selector.
+      touched = false;
       this.selectorOpen = false;
     });
 
     this.renderer.listen("window", "click", (e: any) => {
+      if (touched) return; // prevent click trigger if touch is being used
       if (e.path === undefined) {
         if (e.target.offsetParent === this.accountSelectorRoot.nativeElement) {
-          this.selectorOpen = true;
+          this.selectorOpen = !this.selectorOpen;
           return;
         }
       } else {
         for (let ii = 0; ii < e.path.length; ii++) {
           if (e.path[ii] === this.accountSelectorRoot.nativeElement) {
-            this.selectorOpen = true;
+            this.selectorOpen = !this.selectorOpen;
             return;
           }
         }


### PR DESCRIPTION
When a user is on the browse page and the account is switched the dropdown stays open. 