### PR TITLE
When switching user stay on same page and reload

### DIFF
--- a/src/app/change-account-selector/change-account-selector.component.ts
+++ b/src/app/change-account-selector/change-account-selector.component.ts
@@ -43,8 +43,8 @@ export class ChangeAccountSelectorComponent {
     this.globalVars.messageResponse = null;
     this.globalVars.SetupMessages();
 
-    this.router.onSameUrlNavigation = 'reload'
-    this.router.navigateByUrl(this.router.url);
+    const currentUrl = this.router.url
+    this.router.navigate(['/']).then(() => { this.router.navigateByUrl(currentUrl); })
 
     this.globalVars.isLeftBarMobileOpen = false;
   }

--- a/src/app/change-account-selector/change-account-selector.component.ts
+++ b/src/app/change-account-selector/change-account-selector.component.ts
@@ -43,9 +43,8 @@ export class ChangeAccountSelectorComponent {
     this.globalVars.messageResponse = null;
     this.globalVars.SetupMessages();
 
-    this.router.navigate(["/" + this.globalVars.RouteNames.BROWSE], {
-      queryParamsHandling: "merge",
-    });
+    this.router.onSameUrlNavigation = 'reload'
+    this.router.navigateByUrl(this.router.url);
 
     this.globalVars.isLeftBarMobileOpen = false;
   }


### PR DESCRIPTION
When an account is switched the app always navigates to the browse page. This a bit user-unfriendly.
Also, the data is not reloaded, so when user A likes a post on a feed and switches to user B the like button stays toggled on in the UI.

This PR changes the behavior so that:
* The user stays on the same page when the account is switched
* The route is reloaded so that the data is updated for the current user

This also fixes issue #221