### PR TITLE
De-duplicate infinite scrolling logic 

### DIFF
--- a/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.ts
+++ b/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.ts
@@ -42,7 +42,7 @@ export class CreatorProfileHodlersComponent {
     this.datasource = this.getDatasource();
   }
 
-  // TODO: Cleanup - Create InfiniteScroller class to de-duplicate this logic
+  // TODO: Cleanup - Use InfiniteScroller class to de-duplicate this logic
   getDatasource() {
     return new Datasource<IAdapter<any>>({
       get: (index, count, success) => {

--- a/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.spec.ts
+++ b/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.spec.ts
@@ -1,8 +1,6 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
-
 import { CreatorProfilePostsComponent } from "./creator-profile-posts.component";
 
-// todo anna: add UTs
 describe("CreatorProfilePostsComponent", () => {
   let component: CreatorProfilePostsComponent;
   let fixture: ComponentFixture<CreatorProfilePostsComponent>;

--- a/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.spec.ts
+++ b/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { CreatorProfilePostsComponent } from "./creator-profile-posts.component";
 
+// todo anna: add UTs
 describe("CreatorProfilePostsComponent", () => {
   let component: CreatorProfilePostsComponent;
   let fixture: ComponentFixture<CreatorProfilePostsComponent>;

--- a/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.ts
+++ b/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.ts
@@ -16,6 +16,7 @@ export class CreatorProfilePostsComponent {
   static PAGE_SIZE = 10;
   static BUFFER_SIZE = 5;
   static WINDOW_VIEWPORT = true;
+  static PADDING = 0.5;
 
   @Input() profile: ProfileEntryResponse;
   @Input() afterCommentCreatedCallback: any = null;
@@ -114,6 +115,6 @@ export class CreatorProfilePostsComponent {
     );
   }
 
-  infiniteScroller: InfiniteScroller = new InfiniteScroller(CreatorProfilePostsComponent.PAGE_SIZE, this.getPage, CreatorProfilePostsComponent.WINDOW_VIEWPORT, CreatorProfilePostsComponent.BUFFER_SIZE);
-  datasource: IDatasource<IAdapter<PostEntryResponse>> = this.infiniteScroller.getDatasource();
+  infiniteScroller: InfiniteScroller = new InfiniteScroller(CreatorProfilePostsComponent.PAGE_SIZE, this.getPage, CreatorProfilePostsComponent.WINDOW_VIEWPORT, CreatorProfilePostsComponent.BUFFER_SIZE, CreatorProfilePostsComponent.PADDING);
+  datasource: IDatasource<IAdapter<any>> = this.infiniteScroller.getDatasource();
 }

--- a/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.ts
+++ b/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.ts
@@ -23,7 +23,6 @@ export class CreatorProfilePostsComponent {
   @Input() showProfileAsReserved: boolean;
 
   // Infinite scroll metadata.
-  pageOffset = 0;
   lastPage = null;
 
   loadingFirstPage = true;

--- a/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.ts
+++ b/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.ts
@@ -48,7 +48,6 @@ export class CreatorProfilePostsComponent {
     if (this.lastPage != null && page > this.lastPage) {
       return [];
     }
-    debugger
     this.loadingNextPage = true;
     const lastPostHashHex = this.pagedKeys[page];
     return this.backendApi

--- a/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.ts
+++ b/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.ts
@@ -4,7 +4,7 @@ import { GlobalVarsService } from "../../global-vars.service";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Location } from "@angular/common";
 import { IAdapter, IDatasource } from "ngx-ui-scroll";
-import { InfiniteScroller  } from "src/app/infinite-scroller";
+import { InfiniteScroller } from "src/app/infinite-scroller";
 import * as _ from "lodash";
 
 @Component({
@@ -22,9 +22,7 @@ export class CreatorProfilePostsComponent {
   @Input() afterCommentCreatedCallback: any = null;
   @Input() showProfileAsReserved: boolean;
 
-  // Infinite scroll metadata.
   lastPage = null;
-
   loadingFirstPage = true;
   loadingNextPage = false;
 
@@ -108,6 +106,12 @@ export class CreatorProfilePostsComponent {
     );
   }
 
-  infiniteScroller: InfiniteScroller = new InfiniteScroller(CreatorProfilePostsComponent.PAGE_SIZE, this.getPage.bind(this), CreatorProfilePostsComponent.WINDOW_VIEWPORT, CreatorProfilePostsComponent.BUFFER_SIZE, CreatorProfilePostsComponent.PADDING);
+  infiniteScroller: InfiniteScroller = new InfiniteScroller(
+    CreatorProfilePostsComponent.PAGE_SIZE,
+    this.getPage.bind(this),
+    CreatorProfilePostsComponent.WINDOW_VIEWPORT,
+    CreatorProfilePostsComponent.BUFFER_SIZE,
+    CreatorProfilePostsComponent.PADDING
+  );
   datasource: IDatasource<IAdapter<any>> = this.infiniteScroller.getDatasource();
 }

--- a/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.ts
+++ b/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.ts
@@ -3,7 +3,7 @@ import { BackendApiService, PostEntryResponse, ProfileEntryResponse } from "../.
 import { GlobalVarsService } from "../../global-vars.service";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Location } from "@angular/common";
-import { Datasource, IAdapter, IDatasource } from "ngx-ui-scroll";
+import { IAdapter, IDatasource } from "ngx-ui-scroll";
 import { InfiniteScroller  } from "src/app/infinite-scroller";
 import * as _ from "lodash";
 

--- a/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.ts
+++ b/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.ts
@@ -26,17 +26,11 @@ export class CreatorProfilePostsComponent {
   pageOffset = 0;
   lastPage = null;
 
-  // todo anna: figure out if we need these
   loadingFirstPage = true;
   loadingNextPage = false;
+
   pagedKeys = {
     0: "",
-  };
-
-  pagedRequests = {
-    "-1": new Promise((resolve) => {
-      resolve([]);
-    }),
   };
 
   @Output() blockUser = new EventEmitter();
@@ -54,6 +48,7 @@ export class CreatorProfilePostsComponent {
     if (this.lastPage != null && page > this.lastPage) {
       return [];
     }
+    debugger
     this.loadingNextPage = true;
     const lastPostHashHex = this.pagedKeys[page];
     return this.backendApi
@@ -115,6 +110,6 @@ export class CreatorProfilePostsComponent {
     );
   }
 
-  infiniteScroller: InfiniteScroller = new InfiniteScroller(CreatorProfilePostsComponent.PAGE_SIZE, this.getPage, CreatorProfilePostsComponent.WINDOW_VIEWPORT, CreatorProfilePostsComponent.BUFFER_SIZE, CreatorProfilePostsComponent.PADDING);
+  infiniteScroller: InfiniteScroller = new InfiniteScroller(CreatorProfilePostsComponent.PAGE_SIZE, this.getPage.bind(this), CreatorProfilePostsComponent.WINDOW_VIEWPORT, CreatorProfilePostsComponent.BUFFER_SIZE, CreatorProfilePostsComponent.PADDING);
   datasource: IDatasource<IAdapter<any>> = this.infiniteScroller.getDatasource();
 }

--- a/src/app/creators-leaderboard/creators-leaderboard/creators-leaderboard.component.ts
+++ b/src/app/creators-leaderboard/creators-leaderboard/creators-leaderboard.component.ts
@@ -39,7 +39,7 @@ export class CreatorsLeaderboardComponent implements OnInit {
   // tracks if we've reached the end of all notifications
   lastPage = null;
 
-  // TODO: Cleanup - Create InfiniteScroller class to de-duplicate this logic
+  // TODO: Cleanup - Use InfiniteScroller class to de-duplicate this logic
   datasource: IDatasource = new Datasource({
     get: (index, count, success) => {
       const startIndex = Math.max(index, 0);

--- a/src/app/diamond-posts-page/diamond-posts/diamond-posts.component.ts
+++ b/src/app/diamond-posts-page/diamond-posts/diamond-posts.component.ts
@@ -50,6 +50,7 @@ export class DiamondPostsComponent {
 
   static PAGE_SIZE = 10;
 
+  // TODO: Cleanup - Use InfiniteScroller class to de-duplicate this logic
   getDatasource() {
     return new Datasource<IAdapter<DiamondsPost>>({
       get: (index, count, success) => {

--- a/src/app/infinite-scroller.ts
+++ b/src/app/infinite-scroller.ts
@@ -12,8 +12,21 @@ export class InfiniteScroller {
     private getPage: (page: number) => any[] | Promise<any>,
     private windowViewport: boolean,
     private bufferSize: number = 50,
-    private padding: number = 0
+    private padding: number = undefined
   ) {}
+
+  settingsWithoutPadding = {
+    bufferSize: this.bufferSize,
+    infinite: true, // todo anna: do we need this? or should we pass this in?
+    minIndex: 0,
+    startIndex: 0,
+    windowViewport: this.windowViewport,
+  };
+
+  settingsWithPadding = {
+    ...this.settingsWithoutPadding,
+    padding: this.padding,
+  };
 
   getDatasource(): IDatasource<IAdapter<any>> {
     return new Datasource<IAdapter<any>>({
@@ -49,14 +62,7 @@ export class InfiniteScroller {
           return pageResults.slice(start, end);
         });
       },
-      settings: {
-        bufferSize: this.bufferSize,
-        infinite: true, // todo anna: do we need this? or should we pass this in?
-        minIndex: 0,
-        padding: this.padding, // todo anna: is this used?
-        startIndex: 0,
-        windowViewport: this.windowViewport,
-      },
+      settings: Boolean(this.padding) ? this.settingsWithPadding : this.settingsWithoutPadding,
     });
   }
 }

--- a/src/app/infinite-scroller.ts
+++ b/src/app/infinite-scroller.ts
@@ -12,19 +12,15 @@ export class InfiniteScroller {
     private getPage: (page: number) => any[] | Promise<any>,
     private windowViewport: boolean,
     private bufferSize: number = 50,
-    private padding: number = undefined
+    private padding: number = 0.5
   ) {}
 
-  settingsWithoutPadding = {
+  settings = {
     bufferSize: this.bufferSize,
     infinite: true,
     minIndex: 0,
     startIndex: 0,
     windowViewport: this.windowViewport,
-  };
-
-  settingsWithPadding = {
-    ...this.settingsWithoutPadding,
     padding: this.padding,
   };
 
@@ -62,7 +58,7 @@ export class InfiniteScroller {
           return pageResults.slice(start, end);
         });
       },
-      settings: Boolean(this.padding) ? this.settingsWithPadding : this.settingsWithoutPadding,
+      settings: this.settings,
     });
   }
 }

--- a/src/app/infinite-scroller.ts
+++ b/src/app/infinite-scroller.ts
@@ -17,7 +17,7 @@ export class InfiniteScroller {
 
   settingsWithoutPadding = {
     bufferSize: this.bufferSize,
-    infinite: true, // todo anna: do we need this? or should we pass this in?
+    infinite: true,
     minIndex: 0,
     startIndex: 0,
     windowViewport: this.windowViewport,

--- a/src/app/infinite-scroller.ts
+++ b/src/app/infinite-scroller.ts
@@ -11,7 +11,8 @@ export class InfiniteScroller {
     private pageSize: number,
     private getPage: (page: number) => any[] | Promise<any>,
     private windowViewport: boolean,
-    private bufferSize: number = 50
+    private bufferSize: number = 50,
+    private padding: number = 0
   ) {}
 
   getDatasource(): IDatasource<IAdapter<any>> {
@@ -49,9 +50,11 @@ export class InfiniteScroller {
         });
       },
       settings: {
-        startIndex: 0,
-        minIndex: 0,
         bufferSize: this.bufferSize,
+        infinite: true, // todo anna: do we need this?
+        minIndex: 0,
+        padding: this.padding, // todo anna: is this used?
+        startIndex: 0,
         windowViewport: this.windowViewport,
       },
     });

--- a/src/app/infinite-scroller.ts
+++ b/src/app/infinite-scroller.ts
@@ -19,9 +19,9 @@ export class InfiniteScroller {
     bufferSize: this.bufferSize,
     infinite: true,
     minIndex: 0,
+    padding: this.padding,
     startIndex: 0,
     windowViewport: this.windowViewport,
-    padding: this.padding,
   };
 
   getDatasource(): IDatasource<IAdapter<any>> {

--- a/src/app/infinite-scroller.ts
+++ b/src/app/infinite-scroller.ts
@@ -51,7 +51,7 @@ export class InfiniteScroller {
       },
       settings: {
         bufferSize: this.bufferSize,
-        infinite: true, // todo anna: do we need this?
+        infinite: true, // todo anna: do we need this? or should we pass this in?
         minIndex: 0,
         padding: this.padding, // todo anna: is this used?
         startIndex: 0,

--- a/src/app/manage-follows-page/manage-follows/manage-follows.component.ts
+++ b/src/app/manage-follows-page/manage-follows/manage-follows.component.ts
@@ -47,7 +47,7 @@ export class ManageFollowsComponent implements OnDestroy {
 
   lastPage = null;
 
-  // TODO: Cleanup - Create InfiniteScroller class to de-duplicate this logic
+  // TODO: Cleanup - Use InfiniteScroller class to de-duplicate this logic
   datasource: IDatasource<IAdapter<any>> = new Datasource<IAdapter<any>>({
     get: (index, count, success) => {
       const startIdx = Math.max(index, 0);

--- a/src/app/notifications-page/notifications-list/notifications-list.component.html
+++ b/src/app/notifications-page/notifications-list/notifications-list.component.html
@@ -5,10 +5,10 @@
   Notifications
 </div>
 <div class="global__top-bar__height"></div>
-<div *ngIf="isLoading">
+<div *ngIf="loadingFirstPage">
   <simple-center-loader></simple-center-loader>
 </div>
-<div *ngIf="(!totalItems || totalItems === 0) && !isLoading" class="d-flex justify-content-center mt-30px">
+<div *ngIf="(!totalItems || totalItems === 0) && !loadingFirstPage" class="d-flex justify-content-center mt-30px">
   <span>You don't have any notifications</span>
 </div>
 
@@ -51,7 +51,7 @@
     </div>
   </div>
 </div>
-<simple-center-loader *ngIf="loadingMoreNotifications && !isLoading" [height]="200"></simple-center-loader>
+<simple-center-loader *ngIf="loadingNextPage && !loadingFirstPage" [height]="200"></simple-center-loader>
 <!-- SPACER FOR BOTTOM BAR ON MOBILE -->
 <div class="d-lg-none global__bottom-bar-mobile-height"></div>
 <div class="global__bottom-bar-mobile-height"></div>

--- a/src/app/notifications-page/notifications-list/notifications-list.component.ts
+++ b/src/app/notifications-page/notifications-list/notifications-list.component.ts
@@ -33,11 +33,8 @@ export class NotificationsListComponent implements OnInit {
   // null means we're loading items
   totalItems = null;
 
-  // Track if we're loading notifications for the first time
-  isLoading = true;
-
-  // Track if we're loading the next page of notifications
-  loadingMoreNotifications = false;
+  loadingFirstPage = true;
+  loadingNextPage = false;
 
   constructor(private globalVars: GlobalVarsService, private backendApi: BackendApiService) {}
 
@@ -48,8 +45,8 @@ export class NotificationsListComponent implements OnInit {
       return [];
     }
 
+    this.loadingNextPage = true;
     const fetchStartIndex = this.pagedIndexes[page];
-    this.loadingMoreNotifications = true;
     return this.backendApi
       .GetNotifications(
         this.globalVars.localNode,
@@ -89,8 +86,8 @@ export class NotificationsListComponent implements OnInit {
         }
       )
       .finally(() => {
-        this.loadingMoreNotifications = false;
-        this.isLoading = false;
+        this.loadingFirstPage = false;
+        this.loadingNextPage = false;
       });
   }
 

--- a/src/app/notifications-page/notifications-list/notifications-list.component.ts
+++ b/src/app/notifications-page/notifications-list/notifications-list.component.ts
@@ -22,7 +22,6 @@ export class NotificationsListComponent implements OnInit {
   };
 
   // Infinite scroll metadata.
-  pageOffset = 0;
   lastPage = null; 
 
   // stores a cache of all profiles and posts we've seen

--- a/src/app/notifications-page/notifications-list/notifications-list.component.ts
+++ b/src/app/notifications-page/notifications-list/notifications-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from "@angular/core";
 import { GlobalVarsService } from "../../global-vars.service";
 import { BackendApiService, PostEntryResponse } from "../../backend-api.service";
-import { IAdapter, IDatasource } from "ngx-ui-scroll";
+import { Datasource, IAdapter, IDatasource } from "ngx-ui-scroll";
 import * as _ from "lodash";
 import { AppRoutingModule } from "../../app-routing.module";
 import { InfiniteScroller } from "src/app/infinite-scroller";
@@ -11,10 +11,12 @@ import { InfiniteScroller } from "src/app/infinite-scroller";
   templateUrl: "./notifications-list.component.html",
   styleUrls: ["./notifications-list.component.scss"],
 })
-export class NotificationsListComponent implements OnInit {
+export class NotificationsListComponent {
   static BUFFER_SIZE = 10;
   static PAGE_SIZE = 50;
   static WINDOW_VIEWPORT = true;
+
+  constructor(private globalVars: GlobalVarsService, private backendApi: BackendApiService) {}
 
   // stores a mapping of page number to notification index
   pagedIndexes = {
@@ -32,10 +34,6 @@ export class NotificationsListComponent implements OnInit {
   // Track the total number of items for our empty state
   // null means we're loading items
   totalItems = null;
-
-  constructor(private globalVars: GlobalVarsService, private backendApi: BackendApiService) {}
-
-  ngOnInit() {}
 
   getPage(page: number) {
     if (this.lastPage && page > this.lastPage) {

--- a/src/app/notifications-page/notifications-list/notifications-list.component.ts
+++ b/src/app/notifications-page/notifications-list/notifications-list.component.ts
@@ -4,7 +4,7 @@ import { BackendApiService, PostEntryResponse } from "../../backend-api.service"
 import { IAdapter, IDatasource } from "ngx-ui-scroll";
 import * as _ from "lodash";
 import { AppRoutingModule } from "../../app-routing.module";
-import { InfiniteScroller  } from "src/app/infinite-scroller";
+import { InfiniteScroller } from "src/app/infinite-scroller";
 
 @Component({
   selector: "app-notifications-list",
@@ -22,7 +22,10 @@ export class NotificationsListComponent implements OnInit {
   };
 
   // Infinite scroll metadata.
-  lastPage = null; 
+  lastPage = null;
+
+  loadingFirstPage = true;
+  loadingNextPage = false;
 
   // stores a cache of all profiles and posts we've seen
   profileMap = {};
@@ -31,9 +34,6 @@ export class NotificationsListComponent implements OnInit {
   // Track the total number of items for our empty state
   // null means we're loading items
   totalItems = null;
-
-  loadingFirstPage = true;
-  loadingNextPage = false;
 
   constructor(private globalVars: GlobalVarsService, private backendApi: BackendApiService) {}
 
@@ -133,7 +133,8 @@ export class NotificationsListComponent implements OnInit {
         }
       }
       result.icon = "fas fa-money-bill-wave-alt fc-green";
-      result.action = `${actorName} sent you ${this.globalVars.nanosToBitClout(txnAmountNanos)} ` +
+      result.action =
+        `${actorName} sent you ${this.globalVars.nanosToBitClout(txnAmountNanos)} ` +
         `$CLOUT!</b> (~${this.globalVars.nanosToUSD(txnAmountNanos, 2)})`;
       return result;
     } else if (txnMeta.TxnType === "CREATOR_COIN") {
@@ -300,6 +301,11 @@ export class NotificationsListComponent implements OnInit {
     });
   }
 
-  infiniteScroller: InfiniteScroller = new InfiniteScroller(NotificationsListComponent.PAGE_SIZE, this.getPage.bind(this), NotificationsListComponent.WINDOW_VIEWPORT, NotificationsListComponent.BUFFER_SIZE);
+  infiniteScroller: InfiniteScroller = new InfiniteScroller(
+    NotificationsListComponent.PAGE_SIZE,
+    this.getPage.bind(this),
+    NotificationsListComponent.WINDOW_VIEWPORT,
+    NotificationsListComponent.BUFFER_SIZE
+  );
   datasource: IDatasource<IAdapter<any>> = this.infiniteScroller.getDatasource();
 }

--- a/src/app/notifications-page/notifications-list/notifications-list.component.ts
+++ b/src/app/notifications-page/notifications-list/notifications-list.component.ts
@@ -307,5 +307,5 @@ export class NotificationsListComponent implements OnInit {
     NotificationsListComponent.WINDOW_VIEWPORT,
     NotificationsListComponent.BUFFER_SIZE
   );
-  datasource: IDatasource<IAdapter<any>> = this.infiniteScroller.getDatasource();
+  datasource: IDatasource<IAdapter<PostEntryResponse>> = this.infiniteScroller.getDatasource();
 }

--- a/src/app/notifications-page/notifications-list/notifications-list.component.ts
+++ b/src/app/notifications-page/notifications-list/notifications-list.component.ts
@@ -21,9 +21,7 @@ export class NotificationsListComponent implements OnInit {
     0: -1,
   };
 
-  // Infinite scroll metadata.
   lastPage = null;
-
   loadingFirstPage = true;
   loadingNextPage = false;
 

--- a/src/app/post-thread-page/post-thread/post-thread.component.ts
+++ b/src/app/post-thread-page/post-thread/post-thread.component.ts
@@ -55,7 +55,7 @@ export class PostThreadComponent {
     this.currentPost = _.cloneDeep(this.currentPost);
   }
 
-  // TODO: Cleanup - Create InfiniteScroller class to de-duplicate this logic
+  // TODO: Cleanup - Update InfiniteScroller class to de-duplicate this logic
   getDataSource() {
     return new Datasource<IAdapter<any>>({
       get: (index, count, success) => {

--- a/src/app/trends-page/trends/trends.component.ts
+++ b/src/app/trends-page/trends/trends.component.ts
@@ -73,6 +73,7 @@ export class TrendsComponent implements OnInit {
     this.globalVars.updateLeaderboard(true);
   }
 
+  // TODO: Cleanup - Use InfiniteScroller class to de-duplicate this logic
   datasource: IDatasource<IAdapter<any>> = this.getDatasource();
   getDatasource() {
     return new Datasource<IAdapter<any>>({


### PR DESCRIPTION
## Description
Address 2️⃣ / 8️⃣   of the following todos:
```
// TODO: Cleanup - Create InfiniteScroller class to de-duplicate this logic
```
 
Here, I updated the following components to use the `InfiniteScroller` class, as opposed to implementing their own `getDatasource()` methods
- 1️⃣ `CreatorProfilePostsComponent` 
- 2️⃣ `NotificationsListComponent` 


## Follow-up tasks 
I wanted to keep this relatively small so it's easier to review. I plan on updating the following components next. I will create an issue for those and [link it here](https://github.com/bitclout/frontend/issues/246).
 - 3️⃣ [`CreatorProfileHodlersComponent`](https://github.com/bitclout/frontend/blob/main/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.ts#L45)
 - 4️⃣ [`CreatorsLeaderboardComponent`](https://github.com/bitclout/frontend/blob/main/src/app/creators-leaderboard/creators-leaderboard/creators-leaderboard.component.ts#L42)
 - 5️⃣ [`ManageFollowsComponent`](https://github.com/bitclout/frontend/blob/main/src/app/manage-follows-page/manage-follows/manage-follows.component.ts#L50) 
 - 6️⃣ [`DiamondPostsComponent `](https://github.com/bitclout/frontend/blob/main/src/app/diamond-posts-page/diamond-posts/diamond-posts.component.ts#L53)
 - 7️⃣  [`TrendsComponent`](https://github.com/bitclout/frontend/blob/main/src/app/trends-page/trends/trends.component.ts#L77)

⚠️ The one that I'm not entirely sure how to update is 8️⃣  `PostThreadComponent`. The fetching/promise logic is different ([`subscribe` is being used](https://github.com/bitclout/frontend/blob/main/src/app/post-thread-page/post-thread/post-thread.component.ts#L76)). I think that should be [a separate issue](https://github.com/bitclout/frontend/issues/247). Open to suggestions here.

## Screenshots 
`main` branch | `akutch-infinite-scroll-cleanup` branch
-|-
![before-main](https://user-images.githubusercontent.com/6456722/124818716-607f0880-df39-11eb-8cc8-9124e4e34303.gif) | ![after](https://user-images.githubusercontent.com/6456722/124818719-61b03580-df39-11eb-8372-a2d96fa3b2db.gif)
![notif-before](https://user-images.githubusercontent.com/6456722/124818735-6543bc80-df39-11eb-8820-daaecf365bda.gif) | ![notis-after](https://user-images.githubusercontent.com/6456722/124818751-68d74380-df39-11eb-99b6-676ca1273475.gif)




