### PR TITLE
Change in header above QR code

### DIFF
--- a/src/app/transfer-bitclout/transfer-bitclout.component.html
+++ b/src/app/transfer-bitclout/transfer-bitclout.component.html
@@ -90,7 +90,7 @@
 </button>
 
 <div class="p-15px d-flex flex-column align-items-center">
-  <p>Share to receive $CLOUT</p>
+  <p>Scan QR to Send {{ globalVars.loggedInUser.ProfileEntryResponse.Username }} $Clout</p>
   <img [src]="sendBitCloutQRCode | sanitizeQRCode"/>
 </div>
 

--- a/src/app/transfer-bitclout/transfer-bitclout.component.html
+++ b/src/app/transfer-bitclout/transfer-bitclout.component.html
@@ -90,7 +90,7 @@
 </button>
 
 <div class="p-15px d-flex flex-column align-items-center">
-  <p>Scan QR to Send {{ globalVars.loggedInUser.ProfileEntryResponse.Username }} $Clout</p>
+  <p>Scan QR code to send {{ globalVars.loggedInUser.ProfileEntryResponse?.Username }} $CLOUT</p>
   <img [src]="sendBitCloutQRCode | sanitizeQRCode"/>
 </div>
 


### PR DESCRIPTION
1-Made a small change in header above QR code so that when the screenshot gets shared it communicates to the one who pays/send Clout!

2-Added the receiver  username :)

![Send $CLOUT - BitClout - Google Chrome 08-07-2021 04_56_02 (2)](https://user-images.githubusercontent.com/71114510/124840617-09188100-dfa9-11eb-9d99-bfc106be36e6.png)

