### PR TITLE
De-duplicate infinite scrolling logic [part 2]

### DIFF
--- a/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.ts
+++ b/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.ts
@@ -1,8 +1,6 @@
-import { ChangeDetectorRef, Component, Input } from "@angular/core";
+import { Component, Input } from "@angular/core";
 import { BackendApiService, ProfileEntryResponse, BalanceEntryResponse } from "../../backend-api.service";
 import { GlobalVarsService } from "../../global-vars.service";
-import { ActivatedRoute, Router } from "@angular/router";
-import { Location } from "@angular/common";
 import { IDatasource, IAdapter } from "ngx-ui-scroll";
 import { InfiniteScroller } from "src/app/infinite-scroller";
 

--- a/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.ts
+++ b/src/app/creator-profile-page/creator-profile-hodlers/creator-profile-hodlers.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output, ViewChild } from "@angular/core";
+import { ChangeDetectorRef, Component, Input } from "@angular/core";
 import { BackendApiService, ProfileEntryResponse, BalanceEntryResponse } from "../../backend-api.service";
 import { GlobalVarsService } from "../../global-vars.service";
 import { ActivatedRoute, Router } from "@angular/router";
@@ -16,14 +16,7 @@ export class CreatorProfileHodlersComponent {
   static WINDOW_VIEWPORT = true;
   static BUFFER_SIZE = 5; // todo anna: do we want 5 or default?
 
-  constructor(
-    private globalVars: GlobalVarsService,
-    private backendApi: BackendApiService,
-    private route: ActivatedRoute,
-    private cdr: ChangeDetectorRef,
-    private router: Router,
-    private location: Location
-  ) {}
+  constructor(private globalVars: GlobalVarsService, private backendApi: BackendApiService) {}
 
   @Input() profile: ProfileEntryResponse;
 

--- a/src/app/creators-leaderboard/creators-leaderboard/creators-leaderboard.component.ts
+++ b/src/app/creators-leaderboard/creators-leaderboard/creators-leaderboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Output } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { GlobalVarsService } from "../../global-vars.service";
 import { BackendApiService } from "../../backend-api.service";
 import { AppRoutingModule } from "../../app-routing.module";

--- a/src/app/creators-leaderboard/creators-leaderboard/creators-leaderboard.component.ts
+++ b/src/app/creators-leaderboard/creators-leaderboard/creators-leaderboard.component.ts
@@ -3,8 +3,9 @@ import { GlobalVarsService } from "../../global-vars.service";
 import { BackendApiService } from "../../backend-api.service";
 import { AppRoutingModule } from "../../app-routing.module";
 import { CanPublicKeyFollowTargetPublicKeyHelper } from "../../../lib/helpers/follows/can_public_key_follow_target_public_key_helper";
-import { Datasource, IDatasource } from "ngx-ui-scroll";
+import { IAdapter, IDatasource } from "ngx-ui-scroll";
 import { Title } from "@angular/platform-browser";
+import { InfiniteScroller } from "src/app/infinite-scroller";
 
 @Component({
   selector: "creators-leaderboard",
@@ -13,6 +14,8 @@ import { Title } from "@angular/platform-browser";
 })
 export class CreatorsLeaderboardComponent implements OnInit {
   static PAGE_SIZE = 100;
+  static WINDOW_VIEWPORT = true;
+  static BUFFER_SIZE = 5;
 
   AppRoutingModule = AppRoutingModule;
   appData: GlobalVarsService;
@@ -24,13 +27,6 @@ export class CreatorsLeaderboardComponent implements OnInit {
   // FIME: Replace with real value
   fakeNumHodlers = Math.ceil(Math.random() * 1000) + 1000;
 
-  // stores a mapping of page number to promises
-  pagedRequests = {
-    "-1": new Promise((resolve) => {
-      resolve([]);
-    }),
-  };
-
   // stores a mapping of page number to public key to fetch
   pagedKeys = {
     0: "",
@@ -38,50 +34,6 @@ export class CreatorsLeaderboardComponent implements OnInit {
 
   // tracks if we've reached the end of all notifications
   lastPage = null;
-
-  // TODO: Cleanup - Use InfiniteScroller class to de-duplicate this logic
-  datasource: IDatasource = new Datasource({
-    get: (index, count, success) => {
-      const startIndex = Math.max(index, 0);
-      const endIndex = index + count - 1;
-      if (startIndex > endIndex) {
-        success([]); // empty result
-        return;
-      }
-
-      const startPage = Math.floor(startIndex / CreatorsLeaderboardComponent.PAGE_SIZE);
-      const endPage = Math.floor(endIndex / CreatorsLeaderboardComponent.PAGE_SIZE);
-
-      const pageRequests: any[] = [];
-      for (let i = startPage; i <= endPage; i++) {
-        const existingRequest = this.pagedRequests[i];
-        if (existingRequest) {
-          pageRequests.push(existingRequest);
-        } else {
-          // we need to wait for the previous page before we can fetch the next one
-          const newRequest = this.pagedRequests[i - 1].then((_) => {
-            return this.getPage(i);
-          });
-          this.pagedRequests[i] = newRequest;
-          pageRequests.push(newRequest);
-        }
-      }
-
-      return Promise.all(pageRequests).then((pageResults) => {
-        pageResults = pageResults.reduce((acc, result) => [...acc, ...result], []);
-        const start = startIndex - startPage * CreatorsLeaderboardComponent.PAGE_SIZE;
-        const end = start + endIndex - startIndex + 1;
-        return pageResults.slice(start, end);
-      });
-    },
-    settings: {
-      startIndex: 0,
-      minIndex: 0,
-      bufferSize: 5,
-      windowViewport: true,
-      infinite: true,
-    },
-  });
 
   constructor(
     private globalVars: GlobalVarsService,
@@ -152,4 +104,12 @@ export class CreatorsLeaderboardComponent implements OnInit {
       targetPubKeyBase58Check
     );
   }
+
+  infiniteScroller: InfiniteScroller = new InfiniteScroller(
+    CreatorsLeaderboardComponent.PAGE_SIZE,
+    this.getPage.bind(this),
+    CreatorsLeaderboardComponent.WINDOW_VIEWPORT,
+    CreatorsLeaderboardComponent.BUFFER_SIZE
+  );
+  datasource: IDatasource<IAdapter<any>> = this.infiniteScroller.getDatasource();
 }

--- a/src/app/diamond-posts-page/diamond-posts/diamond-posts.component.ts
+++ b/src/app/diamond-posts-page/diamond-posts/diamond-posts.component.ts
@@ -1,9 +1,10 @@
-import { Component, Input } from "@angular/core";
+import { Component } from "@angular/core";
 import { GlobalVarsService } from "../../global-vars.service";
 import { ActivatedRoute, Router } from "@angular/router";
-import { Datasource, IAdapter, IDatasource } from "ngx-ui-scroll";
+import { IAdapter, IDatasource } from "ngx-ui-scroll";
 import { BackendApiService, DiamondsPost, PostEntryResponse, ProfileEntryResponse } from "../../backend-api.service";
 import * as _ from "lodash";
+import { InfiniteScroller } from "src/app/infinite-scroller";
 
 @Component({
   selector: "diamond-posts",
@@ -11,6 +12,10 @@ import * as _ from "lodash";
   styleUrls: ["./diamond-posts.component.sass"],
 })
 export class DiamondPostsComponent {
+  static BUFFER_SIZE = 10;
+  static PAGE_SIZE = 10;
+  static WINDOW_VIEWPORT = true;
+
   constructor(
     public globalVars: GlobalVarsService,
     private router: Router,
@@ -29,7 +34,6 @@ export class DiamondPostsComponent {
   receiverProfileEntryResponse: ProfileEntryResponse;
   senderProfileEntryResponse: ProfileEntryResponse;
 
-  datasource: IDatasource<IAdapter<any>> = this.getDatasource();
   loadingFirstPage = true;
   loadingNextPage = false;
   pagedKeys = {
@@ -40,59 +44,7 @@ export class DiamondPostsComponent {
     0: 0,
   };
 
-  pagedRequests = {
-    "-1": new Promise((resolve) => {
-      resolve([]);
-    }),
-  };
-
   lastPage = null;
-
-  static PAGE_SIZE = 10;
-
-  // TODO: Cleanup - Use InfiniteScroller class to de-duplicate this logic
-  getDatasource() {
-    return new Datasource<IAdapter<DiamondsPost>>({
-      get: (index, count, success) => {
-        const startIdx = Math.max(index, 0);
-        const endIdx = index + count - 1;
-        if (startIdx > endIdx) {
-          success([]);
-          return;
-        }
-        const startPage = Math.floor(startIdx / DiamondPostsComponent.PAGE_SIZE);
-        const endPage = Math.floor(endIdx / DiamondPostsComponent.PAGE_SIZE);
-
-        const pageRequests: any[] = [];
-        for (let i = startPage; i <= endPage; i++) {
-          const existingRequest = this.pagedRequests[i];
-          if (existingRequest) {
-            pageRequests.push(existingRequest);
-          } else {
-            const newRequest = this.pagedRequests[i - 1].then((_) => {
-              return this.getPage(i);
-            });
-            this.pagedRequests[i] = newRequest;
-            pageRequests.push(newRequest);
-          }
-        }
-
-        return Promise.all(pageRequests).then((pageResults) => {
-          pageResults = pageResults.reduce((acc, result) => [...acc, ...result], []);
-          const start = startIdx - startPage * DiamondPostsComponent.PAGE_SIZE;
-          const end = start + endIdx - startIdx + 1;
-          return pageResults.slice(start, end);
-        });
-      },
-      settings: {
-        startIndex: 0,
-        minIndex: 0,
-        bufferSize: 10,
-        windowViewport: true,
-        infinite: true,
-      },
-    });
-  }
 
   getPage(page: number) {
     if (this.lastPage != null && page > this.lastPage) {
@@ -169,4 +121,12 @@ export class DiamondPostsComponent {
       },
     });
   }
+
+  infiniteScroller: InfiniteScroller = new InfiniteScroller(
+    DiamondPostsComponent.PAGE_SIZE,
+    this.getPage.bind(this),
+    DiamondPostsComponent.WINDOW_VIEWPORT,
+    DiamondPostsComponent.BUFFER_SIZE
+  );
+  datasource: IDatasource<IAdapter<any>> = this.infiniteScroller.getDatasource();
 }

--- a/src/app/manage-follows-page/manage-follows/manage-follows.component.ts
+++ b/src/app/manage-follows-page/manage-follows/manage-follows.component.ts
@@ -5,7 +5,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { Subscription } from "rxjs";
 import { RouteNames, AppRoutingModule } from "../../app-routing.module";
 import { CanPublicKeyFollowTargetPublicKeyHelper } from "../../../lib/helpers/follows/can_public_key_follow_target_public_key_helper";
-import { Datasource, IAdapter, IDatasource } from "ngx-ui-scroll";
+import { IAdapter, IDatasource } from "ngx-ui-scroll";
 import { InfiniteScroller } from "src/app/infinite-scroller";
 
 @Component({

--- a/src/app/manage-follows-page/manage-follows/manage-follows.component.ts
+++ b/src/app/manage-follows-page/manage-follows/manage-follows.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnDestroy } from "@angular/core";
 import { BackendApiService, ProfileEntryResponse } from "../../backend-api.service";
 import { GlobalVarsService } from "../../global-vars.service";
 import { ActivatedRoute, Router } from "@angular/router";
@@ -6,6 +6,7 @@ import { Subscription } from "rxjs";
 import { RouteNames, AppRoutingModule } from "../../app-routing.module";
 import { CanPublicKeyFollowTargetPublicKeyHelper } from "../../../lib/helpers/follows/can_public_key_follow_target_public_key_helper";
 import { Datasource, IAdapter, IDatasource } from "ngx-ui-scroll";
+import { InfiniteScroller } from "src/app/infinite-scroller";
 
 @Component({
   selector: "manage-follows",
@@ -16,6 +17,8 @@ export class ManageFollowsComponent implements OnDestroy {
   static FOLLOWING = "Following";
   static FOLLOWERS = "Followers";
   static PAGE_SIZE = 50;
+  static BUFFER_SIZE = 50;
+  static WINDOW_VIEWPORT = true;
 
   ManageFollowsComponent = ManageFollowsComponent;
   AppRoutingModule = AppRoutingModule;
@@ -34,61 +37,11 @@ export class ManageFollowsComponent implements OnDestroy {
   profileFollowerCount: number = 0;
   loadingFirstPage = true;
   loadingNextPage = false;
+  lastPage = null;
 
   pagedKeys = {
     0: "",
   };
-
-  pagedRequests = {
-    "-1": new Promise((resolve) => {
-      resolve([]);
-    }),
-  };
-
-  lastPage = null;
-
-  // TODO: Cleanup - Use InfiniteScroller class to de-duplicate this logic
-  datasource: IDatasource<IAdapter<any>> = new Datasource<IAdapter<any>>({
-    get: (index, count, success) => {
-      const startIdx = Math.max(index, 0);
-      const endIdx = index + count - 1;
-      if (startIdx > endIdx) {
-        success([]);
-        return;
-      }
-
-      const startPage = Math.floor(startIdx / ManageFollowsComponent.PAGE_SIZE);
-      const endPage = Math.floor(endIdx / ManageFollowsComponent.PAGE_SIZE);
-
-      const pageRequests: any[] = [];
-      for (let i = startPage; i <= endPage; i++) {
-        const existingRequest = this.pagedRequests[i];
-        if (existingRequest) {
-          pageRequests.push(existingRequest);
-        } else {
-          const newRequest = this.pagedRequests[i - 1].then((_) => {
-            return this.getPage(i);
-          });
-          this.pagedRequests[i] = newRequest;
-          pageRequests.push(newRequest);
-        }
-      }
-
-      return Promise.all(pageRequests).then((pageResults) => {
-        pageResults = pageResults.reduce((acc, result) => [...acc, ...result], []);
-        const start = startIdx - startPage * ManageFollowsComponent.PAGE_SIZE;
-        const end = start + endIdx - startIdx + 1;
-        return pageResults.slice(start, end);
-      });
-    },
-    settings: {
-      startIndex: 0,
-      minIndex: 0,
-      bufferSize: 50,
-      windowViewport: true,
-      infinite: true,
-    },
-  });
 
   getPage(page: number) {
     if (this.lastPage != null && page > this.lastPage) {
@@ -247,4 +200,12 @@ export class ManageFollowsComponent implements OnDestroy {
   ngOnDestroy() {
     this.loggedInUserSubscription.unsubscribe();
   }
+
+  infiniteScroller: InfiniteScroller = new InfiniteScroller(
+    ManageFollowsComponent.PAGE_SIZE,
+    this.getPage.bind(this),
+    ManageFollowsComponent.WINDOW_VIEWPORT,
+    ManageFollowsComponent.BUFFER_SIZE
+  );
+  datasource: IDatasource<IAdapter<any>> = this.infiniteScroller.getDatasource();
 }

--- a/src/app/trends-page/trends/trends.component.ts
+++ b/src/app/trends-page/trends/trends.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from "@angular/core";
 import { GlobalVarsService } from "../../global-vars.service";
-import { ActivatedRoute, Router } from "@angular/router";
 import { BackendApiService } from "../../backend-api.service";
 import { HttpClient } from "@angular/common/http";
 import { PulseService } from "../../../lib/services/pulse/pulse-service";


### PR DESCRIPTION
## Description
Closes https://github.com/bitclout/frontend/issues/246

Updates the following components to use the `InfiniteScroller` class, as opposed to implementing their own `getDatasource()` methods:
- `CreatorProfileHodlersComponent`
- `CreatorsLeaderboardComponent`
- `ManageFollowsComponent`
- `DiamondPostsComponent`
- `TrendsComponent`

## Open questions
❓ ~How can I populate my local test node with more data (namely with additional creators)? Or is there another best practice for testing with realistic data?~

~^ If that's still a manual process and one of you have more in your test node, do you mind making sure the pages listed in the **Acceptance Criteria** section below are scrolling as expected with these changes?~ 

✅ I can use @tijno 's test node as he recommended [here](https://github.com/bitclout/frontend/pull/250#issuecomment-876152320)

## Acceptance Criteria
- [x] Creator profile holders are paginating as expected
- [x] Creators leaderboard is paginating as expected
- [x] Manage follows is paginating as expected
- [x] Diamond posts are paginating as expected
- [x] Trends are paginating as expected

## Screenshots
~❗These do not verify pagination works. The images are for reference for the **Acceptance Criteria** above~

Page | Before | After | Route
-|-|-|-
Creator profile holders | ![creator-coin-before](https://user-images.githubusercontent.com/6456722/124939461-1d737280-dfd7-11eb-8816-eea3533c3f81.gif) | ![creator-coin-after](https://user-images.githubusercontent.com/6456722/124939469-1fd5cc80-dfd7-11eb-8cc2-661e783b556f.gif) | `http://localhost:4200/u/<username>?tab=creator-coin`
Creators leaderboard | ![leaderboard-before](https://user-images.githubusercontent.com/6456722/124940106-b0141180-dfd7-11eb-94e3-b79bb754b759.gif) | ![leaderboard-after](https://user-images.githubusercontent.com/6456722/124940135-b4d8c580-dfd7-11eb-95bf-0c0acfd5b61d.gif) | `http://localhost:4200/creators`
Manage follows | ![followers-before](https://user-images.githubusercontent.com/6456722/124940791-46483780-dfd8-11eb-86da-8ffeefd04854.gif) | ![followers-after](https://user-images.githubusercontent.com/6456722/124940835-5102cc80-dfd8-11eb-932c-cde9bdbfa417.gif) | `http://localhost:4200/u/<username>/following`
Diamond posts | ![diamond-before](https://user-images.githubusercontent.com/6456722/124938650-78589a00-dfd6-11eb-9cfe-1d9fbf850f39.gif) | ![diamond-after-actual](https://user-images.githubusercontent.com/6456722/124938661-7a225d80-dfd6-11eb-83b9-1b86dd6527a0.gif) | `http://localhost:4200/u/<username_a>/diamonds/<username_b>`
Trends | ![trend-before](https://user-images.githubusercontent.com/6456722/124941177-9cb57600-dfd8-11eb-887f-613965189798.gif) | ![trend-after](https://user-images.githubusercontent.com/6456722/124941179-9d4e0c80-dfd8-11eb-9781-1ab1d9c937b3.gif) |`http://localhost:4200/trends`




