### PR TITLE
Fix cake-theme.ts button color to match link

### DIFF
--- a/src/app/theme/cake-theme.ts
+++ b/src/app/theme/cake-theme.ts
@@ -22,7 +22,7 @@ export const cakeTheme: Theme = {
     "--cblue": "#457b9d",
     "--cred": "#ff3298",
     "--cgreen": "#69ab4f",
-    "--button": "#47205c",
+    "--button": "#009aff",
     "--loading": "#d2a59d",
   },
 };


### PR DESCRIPTION
Restoring blue button color in cake-theme to #009aff to match link color per original.

Optional: If Mae/Nina prefer it stay purple, your decision.  I think the other purple was too dark and an unintended consequence of update to add button class to theme (which is very cool, btw.)