### PR TITLE
Mars theme.ts

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -127,6 +127,7 @@ import { icydarkTheme } from "./theme/icy-dark-theme";
 import { legendsTheme } from "./theme/legends-theme";
 // Themes for BitClout by Brix Boston @brixboston100 for Modular Themes by Carsen Klock @carsenk
 import { cakeTheme } from "./theme/cake-theme";
+import { marsTheme } from "./theme/mars-theme";
 //Theme for BitClout by @mrpreet
 import { greenishTheme } from "./theme/greenish-theme";
 
@@ -251,7 +252,7 @@ import { greenishTheme } from "./theme/greenish-theme";
     RatingModule.forRoot(),
     CollapseModule.forRoot(),
     ThemeModule.forRoot({
-      themes: [lightTheme, darkTheme, icydarkTheme, legendsTheme, cakeTheme, greenishTheme],
+      themes: [lightTheme, darkTheme, icydarkTheme, legendsTheme, cakeTheme, marsTheme, greenishTheme],
       active:
         localStorage.getItem("theme") ||
         (window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark"),

--- a/src/app/theme/mars-theme.ts
+++ b/src/app/theme/mars-theme.ts
@@ -1,0 +1,28 @@
+import { Theme } from "./symbols";
+
+export const marsTheme: Theme = {
+  key: "mars",
+  name: "Mars Theme",
+  properties: {
+    "--background": "#521f20",
+    "--text": "#f5d4cb",
+    "--grey": "#c6a7a7",
+    "--secondary": "#672529",
+    "--secalt": "#741c24",
+    "--textalt": "#c6a7a7",
+    "--norm": "#c6a7a7",
+    "--formbg": "#741c24",
+    "--link": "#f44336",
+    "--hover": "#dc3545",
+    "--border": "#672529",
+    "--mborder": "672529",
+    "--filter": "brightness(116%) contrast(100%) hue-rotate(116deg) invert(98%) sepia(1%) saturate(264%)",
+    "--unread": "#672529",
+    "--topbar": "#bf3a30",
+    "--cblue": "#238eff",
+    "--cred": "#f44336",
+    "--cgreen": "#ffc107",
+    "--button": "#f44336",
+    "--loading": "#f44336",
+  },
+};


### PR DESCRIPTION
🔴 Mars Theme was inspired by a recent quote by Grimes on Instagram saying, she was "Ready to die with the red dirt of mars beneath my feet." I thought also of the movies Dune and Total Recall. I felt it might make our favorite Teslans feel more at home on Bitclout with a native theme inspired by their aspiring future home planet. I went with a high tech led type of red link and button to employ the new button class and give that studio-esq Red-Light-Special look.

[It might also be a nice Valentines Day type of theme for Valentines screenshots. 💖]

I can't do a screenshot with the new merge of the button class, but it's red to match the links and I would love if anyone could make a screenshot for me if it's rejected or merged.

Welcoming any core team adjustments to logo or whatever else.

![mars](https://user-images.githubusercontent.com/82254764/125026147-fc039c80-e051-11eb-85f9-b8fb530f9787.jpg)
