### PR TITLE
Allow blocking/viewing of blacklisted profiles

### DIFF
--- a/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.ts
+++ b/src/app/creator-profile-page/creator-profile-details/creator-profile-details.component.ts
@@ -166,7 +166,7 @@ export class CreatorProfileDetailsComponent {
     this.loading = true;
     this.backendApi.GetSingleProfile(this.globalVars.localNode, "", this.userName).subscribe(
       (res) => {
-        if (!res || res.IsBlacklisted) {
+        if (!res) {
           this.loading = false;
           this.router.navigateByUrl("/" + this.appData.RouteNames.NOT_FOUND, { skipLocationChange: true });
           return;


### PR DESCRIPTION
This allows users to block a blacklisted user from spamming their notifications, as well as checking a blacklisted user's coin holders.

This does not change the search or feed's blacklisting functionality.