### PR TITLE
reclout button now shows sum of reclout and QuoteReclouts 

### DIFF
--- a/src/app/feed/feed-post-icon-row/feed-post-icon-row.component.html
+++ b/src/app/feed/feed-post-icon-row/feed-post-icon-row.component.html
@@ -64,7 +64,7 @@
         </a>
       </ng-template>
     </div>
-    <span *ngIf="!hideNumbers">{{ postContent.RecloutCount }}</span>
+    <span *ngIf="!hideNumbers">{{ postContent.RecloutCount + postContent.QuoteRecloutCount}}</span>
   </div>
 
   <div


### PR DESCRIPTION
The reclout button used to show reclout count only but just like any other platforms, reclout button should show sum of both reclouts and quote reclouts on a post.

preview (see the difference of count on reclout button ):
![Pr3](https://user-images.githubusercontent.com/55331140/125161475-3d09c700-e1a0-11eb-8da0-c21af4c59302.png)
