### PR TITLE
search for username even if there is @ in front or spaces around user…

### DIFF
--- a/src/app/search-bar/search-bar.component.ts
+++ b/src/app/search-bar/search-bar.component.ts
@@ -93,7 +93,7 @@ export class SearchBarComponent implements OnInit {
         this.globalVars.localNode,
         "" /*PublicKeyBase58Check*/,
         "" /*Username*/,
-        this.searchText /*UsernamePrefix*/,
+        this.searchText.trim().replace(/^@/, '') /*UsernamePrefix*/,
         "" /*Description*/,
         "" /*Order by*/,
         20 /*NumToFetch*/,


### PR DESCRIPTION
Simple update to handle situations when users try to put usernames including '@' and/or extra spaces in front and at the end in Bitclout search bar like for example  

'@SearchClout' 
'@SearchClout   '
'  @SearchClout   '
'   SearchClout'
'   SearchClout   '  

![image](https://user-images.githubusercontent.com/20090030/125164211-c4077100-e199-11eb-9364-41913a049f6b.png)
