### PR TITLE
Book.ts theme

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -127,6 +127,7 @@ import { icydarkTheme } from "./theme/icy-dark-theme";
 import { legendsTheme } from "./theme/legends-theme";
 // Themes for BitClout by Brix Boston @brixboston100 for Modular Themes by Carsen Klock @carsenk
 import { cakeTheme } from "./theme/cake-theme";
+import { bookTheme } from "./theme/book-theme";
 //Theme for BitClout by @mrpreet
 import { greenishTheme } from "./theme/greenish-theme";
 
@@ -251,7 +252,7 @@ import { greenishTheme } from "./theme/greenish-theme";
     RatingModule.forRoot(),
     CollapseModule.forRoot(),
     ThemeModule.forRoot({
-      themes: [lightTheme, darkTheme, icydarkTheme, legendsTheme, cakeTheme, greenishTheme],
+      themes: [lightTheme, darkTheme, icydarkTheme, legendsTheme, cakeTheme, bookTheme, greenishTheme],
       active:
         localStorage.getItem("theme") ||
         (window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark"),

--- a/src/app/theme/book-theme.ts
+++ b/src/app/theme/book-theme.ts
@@ -1,0 +1,28 @@
+import { Theme } from "./symbols";
+
+export const bookTheme: Theme = {
+  key: "book",
+  name: "Book Theme",
+  properties: {
+    "--background": "#fbeec1",
+    "--text": "#463e34",
+    "--grey": "#463e34",
+    "--secondary": "#F5E6B6",
+    "--secalt": "#F5E6B6",
+    "--textalt": "#bc986a",
+    "--norm": "#806647",
+    "--formbg": "#f5e6b5",
+    "--link": "#007BFF",
+    "--hover": "#82acd8",
+    "--border": "#f5e6b5",
+    "--mborder": "#daad86",
+    "--filter": "grayscale(0.5) sepia(1) opacity(0.78)",
+    "--unread": "#fbeec1",
+    "--topbar": "#bc986a",
+    "--cblue": "#659dbd",
+    "--cred": "#ca2100",
+    "--cgreen": "#3f9248",
+    "--button": "#bc986a",
+    "--loading": "#bc986a",
+  },
+};


### PR DESCRIPTION
📖 Book Theme is an eReader style alternative light theme that's inspired by Kindle and Opera reader mode designed to reduce eye strain without the "wired" effect of dark mode or blue light. The antique and sepia tones also help remedy glare and screen contrast in natural daylight and strong backlight. Book Theme might be nice when accessing Bitclout on tablet devices, iPads, etc. 

![book](https://user-images.githubusercontent.com/82254764/125180814-aa335180-e1cc-11eb-8149-e1cf347bfa98.jpg)
![book2](https://user-images.githubusercontent.com/82254764/125180815-aa335180-e1cc-11eb-942b-a55adb978871.jpg)
![book3](https://user-images.githubusercontent.com/82254764/125180816-aacbe800-e1cc-11eb-92ad-911db01259ca.jpg)
![book4](https://user-images.githubusercontent.com/82254764/125180817-aacbe800-e1cc-11eb-8c96-cc5f007ee8e2.jpg)
