### PR TITLE
Posts can't have JUST whitespaces

### DIFF
--- a/src/app/feed/feed-create-post/feed-create-post.component.html
+++ b/src/app/feed/feed-create-post/feed-create-post.component.html
@@ -98,7 +98,7 @@
     class="btn btn-primary font-weight-bold ml-15px fs-14px br-12px"
     style="height: 36px; width: 75px; line-height: 15px"
     [ngClass]="{
-      disabled: (postInput.length <= 0 && !postImageSrc) || characterCountExceedsMaxLength(),
+      disabled: (postInput.length <= 0 && !postImageSrc) || characterCountExceedsMaxLength() || !postInput.trim(),
       'btn-loading': submittingPost
     }"
     (click)="_createPost()"

--- a/src/app/feed/feed-create-post/feed-create-post.component.ts
+++ b/src/app/feed/feed-create-post/feed-create-post.component.ts
@@ -132,8 +132,8 @@ export class FeedCreatePostComponent implements OnInit {
       return;
     }
 
-    // post can't be blank
-    if (this.postInput.length === 0 && !this.postImageSrc) {
+    // post can't be blank and it can't have just whitespaces
+    if ((this.postInput.length === 0 && !this.postImageSrc) || !this.postInput.trim()) {
       return;
     }
 


### PR DESCRIPTION
BitClout.com allows users to do posts which have nothing but "JUST" white-spaces.
For example:
![Screenshot from 2021-07-12 15-31-57](https://user-images.githubusercontent.com/55331140/125278725-b506f700-e330-11eb-8a21-f31c79139fe7.png)

This PR solves this problem. Now users can't post with just blank-spaces. This applies to comments/quotes as well


