### PR TITLE
Fix redirecting when switching accounts

### DIFF
--- a/src/app/change-account-selector/change-account-selector.component.ts
+++ b/src/app/change-account-selector/change-account-selector.component.ts
@@ -43,7 +43,7 @@ export class ChangeAccountSelectorComponent {
     this.globalVars.SetupMessages();
 
     const currentUrl = this.router.url;
-    this.router.navigate(["/"]).then(() => {
+    this.router.navigate(["/" + this.globalVars.RouteNames.BROWSE]).then(() => {
       this.router.navigateByUrl(currentUrl);
     });
 


### PR DESCRIPTION
Preserve selected tab when switching accounts on the feed page

Fixes #289