### PR TITLE
No more annoying lower case mentions and cashtags

### DIFF
--- a/src/lib/pipes/sanitize-and-auto-link-pipe.ts
+++ b/src/lib/pipes/sanitize-and-auto-link-pipe.ts
@@ -32,10 +32,6 @@ export class SanitizeAndAutoLinkPipe implements PipeTransform {
 
     // Only link usernames and cashtags for now (not hashtags etc)
     entities = _.filter(entities, (entity) => entity.screenName || entity.cashtag);
-    entities = _.each(entities, (entity) => {
-      entity.screenName = entity.screenName?.toLowerCase();
-      entity.cashtag = entity.cashtag?.toLowerCase();
-    });
 
     const textWithMentionLinks = twitter.autoLinkEntities(text, entities, {
       usernameUrlBase: `/${RouteNames.USER_PREFIX}/`,


### PR DESCRIPTION
Mentions and Cashtags were in lower case before and to be honest it was annoying.
Idea by @HPaulson 

Before:
![Screenshot from 2021-07-14 18-19-14](https://user-images.githubusercontent.com/55331140/125625020-0a0f93a1-0888-4459-aecf-c48b6989fd38.png)

After:
![Screenshot from 2021-07-14 18-19-22](https://user-images.githubusercontent.com/55331140/125625035-e40ef988-7b6f-478a-ba04-97ab523d8910.png)

PS. it works for $CashTags as well
