### PR TITLE
fix infinte scrolling when switching between different trends

### DIFF
--- a/src/app/infinite-scroller.ts
+++ b/src/app/infinite-scroller.ts
@@ -61,4 +61,12 @@ export class InfiniteScroller {
       settings: this.settings,
     });
   }
+
+  reset(): void {
+    this.pagedRequests = {
+      "-1": new Promise((resolve) => {
+        resolve([]);
+      }),
+    };
+  }
 }

--- a/src/app/trends-page/trends/trends.component.ts
+++ b/src/app/trends-page/trends/trends.component.ts
@@ -60,6 +60,7 @@ export class TrendsComponent implements OnInit {
     this.activeRightTabOption = rightTabOption;
     this.selectedOptionWidth = rightTabOption.width + "px";
     this.loading = true;
+    this.infiniteScroller.reset();
     this.datasource.adapter.reset().then(() => (this.loading = false));
   }
 


### PR DESCRIPTION
Currently, when switching between tabs, the paged requests weren't being reset. The page will get stuck with a loading spinner when selecting a different trend, because certain attributes are null or missing.