### PR TITLE
fix arweave.net csp

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -51,7 +51,7 @@ header @html Content-Security-Policy "
     'unsafe-inline'
     https://fonts.googleapis.com
     https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css;
-  img-src 'self' data: i.imgur.com images.bitclout.com quickchart.io arweave.net;
+  img-src 'self' data: i.imgur.com images.bitclout.com quickchart.io *.arweave.net;
   font-src 'self'
     https://fonts.googleapis.com
     https://fonts.gstatic.com

--- a/Caddyfile
+++ b/Caddyfile
@@ -51,7 +51,7 @@ header @html Content-Security-Policy "
     'unsafe-inline'
     https://fonts.googleapis.com
     https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css;
-  img-src 'self' data: i.imgur.com images.bitclout.com quickchart.io *.arweave.net;
+  img-src 'self' data: i.imgur.com images.bitclout.com quickchart.io arweave.net *.arweave.net;
   font-src 'self'
     https://fonts.googleapis.com
     https://fonts.gstatic.com


### PR DESCRIPTION
Arweave URLs redirect to random subdomain so I needed `*.arweave.net` in the img-src csp to get this to load.

eg: https://arweave.net/RvK3XdcfuTAA5KMB3j0_wNbXgOJ3CA8J8I7yGkP4rfk redirects to https://i3zloxoxd64taaheuma54pj7ydlnpahco4ea6cpqr3zbuq7yvx4q.arweave.net/RvK3XdcfuTAA5KMB3j0_wNbXgOJ3CA8J8I7yGkP4rfk

PR run repo also
https://github.com/bitclout/run/pull/73