### PR TITLE
always show NFT details of quoted content if quoted post is NFT, fix styling of quoted content on post thread page

### DIFF
--- a/src/app/feed/feed-post/feed-post.component.html
+++ b/src/app/feed/feed-post/feed-post.component.html
@@ -14,7 +14,7 @@
      - market-feed component -->
 <div
   class="d-flex flex-column"
-  [ngClass]="{'br-12px': setBorder || cardStyle , 'm-15px': cardStyle, 'js-feed-post-hover': hoverable, 'border': setBorder || cardStyle, 'feed-post__quoted-content': hoverable && isQuotedContent }">
+  [ngClass]="{'br-12px': setBorder || cardStyle , 'm-15px': cardStyle && !isQuotedContent, 'js-feed-post-hover': hoverable, 'border': setBorder || cardStyle, 'feed-post__quoted-content': hoverable && isQuotedContent }">
   <div class="w-100">
     <div
       *ngIf="post.IsHidden"
@@ -263,25 +263,19 @@
               ></iframe>
             </div>
 
-            <div
+            <feed-post
               *ngIf="quotedContent && showQuotedContent"
-              class="br-12px"
-              [ngClass]="{ 'border': !cardStyle }"
-            >
-              <feed-post
-                *ngIf="quotedContent && showQuotedContent"
-                [post]="quotedContent"
-                [isQuotedContent]="true"
-                [includePaddingOnPost]="true"
-                [showIconRow]="false"
-                [showDropdown]="false"
-                [showQuotedContent]="false"
-                [contentShouldLinkToThread]="contentShouldLinkToThread"
-                [hoverable]="hoverable"
-                [showNFTDetails]="showNFTDetails && !postContent.IsNFT"
-                [cardStyle]="cardStyle"
-              ></feed-post>
-            </div>
+              [post]="quotedContent"
+              [isQuotedContent]="true"
+              [includePaddingOnPost]="true"
+              [showIconRow]="false"
+              [showDropdown]="false"
+              [showQuotedContent]="false"
+              [contentShouldLinkToThread]="contentShouldLinkToThread"
+              [hoverable]="hoverable"
+              [showNFTDetails]="true"
+              [cardStyle]="true"
+            ></feed-post>
 
 
             <!-- Bottom Buttons -->


### PR DESCRIPTION
currently on bitclout.com:
![image](https://user-images.githubusercontent.com/81658138/127433486-d9bd97dc-7aef-4c69-93a1-028814571fa6.png)

after updates:
![image](https://user-images.githubusercontent.com/81658138/127433563-9a3e6326-f35e-40cd-9abb-7a1c36e01340.png)

- also fixes border when hovering over quoted content