### PR TITLE
chore (feed-create-post): Remove unused 'postImage' viewchild

### DIFF
--- a/src/app/feed/feed-create-post/feed-create-post.component.ts
+++ b/src/app/feed/feed-create-post/feed-create-post.component.ts
@@ -24,7 +24,6 @@ export class FeedCreatePostComponent implements OnInit {
 
   isComment: boolean;
 
-  @ViewChild("postImage") postImage;
   @ViewChild("autosize") autosize: CdkTextareaAutosize;
 
   randomMovieQuote = "";


### PR DESCRIPTION
Please double-check, but the postImage viewchild is not used anywhere. I think we should remove it.