### PR TITLE
fix: lowest bid shows highest bid

### DIFF
--- a/src/app/feed/feed-post/feed-post.component.html
+++ b/src/app/feed/feed-post/feed-post.component.html
@@ -478,11 +478,14 @@
       <div>
     </div>
     <div *ngIf="showExpandedNFTDetails && (highBid || lowBid)" [ngClass]="{'pt-15px': globalVars.isMobile()}">
-      <div *ngIf="highBid != null">
+      <div *ngIf="highBid != 0">
         Highest: {{ globalVars.nanosToBitClout(highBid, 5) }} CLOUT <span class="text-grey7">(~{{ globalVars.nanosToUSD(highBid, 2) }})</span>
       </div>
-      <div *ngIf="lowBid != null">
+      <div *ngIf="lowBid != 0 && highBid > lowBid && lowBid > minBid">
         From: {{ globalVars.nanosToBitClout(lowBid, 5) }} CLOUT <span class="text-grey7">(~{{ globalVars.nanosToUSD(lowBid, 2) }})</span>
+      </div>
+      <div *ngIf="lowBid == 0 || minBid > lowBid">
+        Min Bid: {{ globalVars.nanosToBitClout(minBid, 5) }} CLOUT <span class="text-grey7">(~{{ globalVars.nanosToUSD(minBid, 2) }})</span>
       </div>
     </div>
   </div>

--- a/src/app/feed/feed-post/feed-post.component.ts
+++ b/src/app/feed/feed-post/feed-post.component.ts
@@ -197,7 +197,8 @@ export class FeedPostComponent implements OnInit {
           );
           this.showPlaceABid = !!(this.availableSerialNumbers.length - this.myAvailableSerialNumbers.length);
           this.highBid = _.maxBy(this.availableSerialNumbers, "HighestBidAmountNanos")?.HighestBidAmountNanos || 0;
-          this.lowBid = _.minBy(this.availableSerialNumbers, "LowestBidAmountNanos")?.LowestBidAmountNanos || 0;
+          this.lowBid = _.minBy(this.availableSerialNumbers, "HighestBidAmountNanos")?.HighestBidAmountNanos || 0;
+          this.minBid = _.minBy(this.availableSerialNumbers, "MinBidAmountNanos")?.MinBidAmountNanos || 0;
         });
     }
   }

--- a/src/app/feed/feed-post/feed-post.component.ts
+++ b/src/app/feed/feed-post/feed-post.component.ts
@@ -197,7 +197,7 @@ export class FeedPostComponent implements OnInit {
           );
           this.showPlaceABid = !!(this.availableSerialNumbers.length - this.myAvailableSerialNumbers.length);
           this.highBid = _.maxBy(this.availableSerialNumbers, "HighestBidAmountNanos")?.HighestBidAmountNanos || 0;
-          this.lowBid = _.minBy(this.availableSerialNumbers, "HighestBidAmountNanos")?.HighestBidAmountNanos || 0;
+          this.lowBid = _.minBy(this.availableSerialNumbers, "LowestBidAmountNanos")?.LowestBidAmountNanos || 0;
         });
     }
   }


### PR DESCRIPTION
Lowest Bid bug fixed.

![20210810-eL4BhOWp](https://user-images.githubusercontent.com/69529928/128908750-9d957e34-db88-4a40-bb1e-09b5c5b9f791.png)

Eg:

https://bitclout.com/nft/ac20e9cb5a7e6cec8955880f9f563ea6853cf5a963fb34aa6eb5f84e38195331?nftTab=for_sale&tab=posts&feedTab=Following

Fix live on tijn.club

Eg:

https://tijn.club/nft/ac20e9cb5a7e6cec8955880f9f563ea6853cf5a963fb34aa6eb5f84e38195331?nftTab=for_sale&tab=posts&feedTab=Following

