### PR TITLE
fix: Fixed number formatting for displayed USD amounts

### DIFF
--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -381,6 +381,7 @@ export class GlobalVarsService {
       style: "currency",
       currency: "USD",
       minimumFractionDigits: decimal,
+      maximumFractionDigits: decimal,
     });
     return this.formatUSDMemo[num][decimal];
   }


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/88362450/128910199-da28f031-5899-4d7d-812f-da0ce7b314a6.png)
![image](https://user-images.githubusercontent.com/88362450/128910279-5a1b4317-2ae1-4645-9825-f08668a7d7c2.png)
![image](https://user-images.githubusercontent.com/88362450/128910324-caac0bfa-f5f6-499b-92db-103bba74fbfe.png)

After:
![image](https://user-images.githubusercontent.com/88362450/128910365-3888d235-9f23-4c2d-a2f2-a51209bbab8b.png)
![image](https://user-images.githubusercontent.com/88362450/128910399-b0ea3078-aa87-4ea6-a7fd-d5af495095c2.png)
![image](https://user-images.githubusercontent.com/88362450/128910429-f1823c19-23ec-4aa5-84f4-6a9108b30d8f.png)
