### PR TITLE
CLOUT Diamonds

### DIFF
--- a/src/app/creator-profile-page/creator-diamonds/creator-diamonds.component.html
+++ b/src/app/creator-profile-page/creator-diamonds/creator-diamonds.component.html
@@ -42,7 +42,7 @@
       <simple-center-loader *ngIf="isLoading"></simple-center-loader>
       <div *ngIf="!isLoading || loadingNewSelection">
         <div #uiScroll *uiScroll="let row of datasource">
-          <div *ngIf="!row.totalRow">
+          <div *ngIf="!row.totalRow && row.ProfileEntryResponse">
             <div
               class="link--unstyled cursor-pointer"
               [routerLink]="[
@@ -55,7 +55,6 @@
               <div class="row no-gutters py-10px border-bottom mb-0">
                 <div class="col-5 d-flex align-items-left mb-0">
                   <div
-                    *ngIf="row.ProfileEntryResponse"
                     [routerLink]="['/' + globalVars.RouteNames.USER_PREFIX, row.ProfileEntryResponse.Username]"
                     class="d-flex align-items-center link--unstyled"
                   >
@@ -94,6 +93,41 @@
                 </div>
                 <div class="col-3 mb-0 d-flex align-items-center justify-content-center">
                   {{ row.TotalDiamonds }}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div *ngIf="row.anonDiamondsRow">
+            <div
+              class="link--unstyled"
+            >
+              <div class="row no-gutters py-10px border-bottom mb-0">
+                <div class="col-5 d-flex align-items-left mb-0">
+                  <div
+                    class="d-flex align-items-center link--unstyled"
+                  >
+                    <div
+                      class="creator-profile-details__hodler-avatar mr-10px"
+                      style="background-image: url('/assets/img/default_profile_pic.png')"
+                    ></div>
+                    <div
+                      class="text-truncate"
+                      style="font-size: 14px"
+                      [ngStyle]="{ 'max-width': globalVars.isMobile() ? '100px' : '200px' }"
+                    >
+                      <span>Anonymous</span>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-4 mb-0 d-flex align-items-center justify-flex-start">
+                  <i
+                    *ngFor="let diamond of counter(highestAnonDiamondLevel)"
+                    class="icon-diamond fs-20px d-block"
+                    style="margin-right: -7px"
+                  ></i>
+                </div>
+                <div class="col-3 mb-0 d-flex align-items-center justify-content-center">
+                  {{ totalAnonDiamonds }}
                 </div>
               </div>
             </div>

--- a/src/app/creator-profile-page/creator-diamonds/creator-diamonds.component.ts
+++ b/src/app/creator-profile-page/creator-diamonds/creator-diamonds.component.ts
@@ -23,6 +23,9 @@ export class CreatorDiamondsComponent implements OnInit {
   CreatorDiamondsComponent = CreatorDiamondsComponent;
   datasource: IDatasource<IAdapter<any>> = this.getDatasource();
   loadingNewSelection = false;
+  totalAnonDiamonds = 0;
+  totalAnonDiamondValue = 0;
+  highestAnonDiamondLevel = 0
 
   constructor(private _globalVars: GlobalVarsService, private backendApi: BackendApiService) {
     this.globalVars = _globalVars;
@@ -39,10 +42,34 @@ export class CreatorDiamondsComponent implements OnInit {
       .subscribe(
         (res) => {
           this.diamondSummaryList = res.DiamondSenderSummaryResponses;
+
+          // Calculate the number of diamonds that have come from
+          // anonymous sources, and reformat the list to remove the
+          // anonymous entries.
+          let diamondListWithoutAnon = []
+          for (let ii = 0; ii < this.diamondSummaryList?.length; ii++) {
+            if (!this.diamondSummaryList[ii].ProfileEntryResponse && this.diamondSummaryList[ii].SenderPublicKeyBase58Check) {
+              this.totalAnonDiamonds += this.diamondSummaryList[ii].TotalDiamonds;
+              this.totalAnonDiamondValue += this.sumDiamondValueForUser(this.diamondSummaryList[ii])
+
+              if (this.diamondSummaryList[ii].HighestDiamondLevel > this.highestAnonDiamondLevel) {
+                this.highestAnonDiamondLevel = this.diamondSummaryList[ii].HighestDiamondLevel
+              }
+            } else {
+              diamondListWithoutAnon.push(this.diamondSummaryList[ii])
+            }
+          }
+          this.diamondSummaryList = diamondListWithoutAnon;
+
+          if (this.totalAnonDiamonds) {
+            this.diamondSummaryList.push({ anonDiamondsRow: true });
+          }
+
           if (this.diamondSummaryList.length) {
             this.diamondSummaryList.push({ totalRow: true });
           }
           this.totalDiamonds = res.TotalDiamonds;
+
         },
         (err) => {
           this.globalVars._alertError(this.backendApi.parseProfileError(err));
@@ -65,15 +92,23 @@ export class CreatorDiamondsComponent implements OnInit {
     }
   }
 
+  sumDiamondValueForUser(diamondSummary: any): number {
+    let total = 0
+    for (const diamondLevel in diamondSummary.DiamondLevelMap) {
+      if (diamondLevel in this.globalVars.diamondLevelMap) {
+        total += this.globalVars.diamondLevelMap[diamondLevel] * diamondSummary.DiamondLevelMap[diamondLevel];
+      }
+    }
+    return total
+  }
+
   valueOfAllDiamonds(): number {
     let total = 0;
     this.diamondSummaryList.map((diamondSummary) => {
-      for (const diamondLevel in diamondSummary.DiamondLevelMap) {
-        if (diamondLevel in this.globalVars.diamondLevelMap) {
-          total += this.globalVars.diamondLevelMap[diamondLevel] * diamondSummary.DiamondLevelMap[diamondLevel];
-        }
-      }
+      total += this.sumDiamondValueForUser(diamondSummary)
     });
+    // Add the total amount from anon diamonds
+    total += this.totalAnonDiamondValue
     return this.globalVars.nanosToUSDNumber(total);
   }
 

--- a/src/app/feed/feed-post-icon-row/feed-post-icon-row.component.html
+++ b/src/app/feed/feed-post-icon-row/feed-post-icon-row.component.html
@@ -90,25 +90,7 @@
           <b>@{{ postContent.ProfileEntryResponse.Username }}</b>
           will receive the amount shown as
           <b>a tip</b>
-          from you, paid in
-          <b>${{ globalVars.loggedInUser.ProfileEntryResponse.Username }} coin</b>.
-          <i class="fas fa-info-circle"></i>
-        </div>
-        <div
-          class="fs-14px w-100 mt-3 mb-1"
-          id="diamondInfoCollapse"
-          [collapse]="collapseDiamondInfo"
-          [isAnimated]="true"
-        >
-          <div class="mb-2">When you give a diamond:</div>
-          <ul class="mb-2">
-            <li>The receiver gets a tip paid in your creator coin</li>
-            <li>A collectible badge shows up on the receiver's profile</li>
-            <li>The receiver's comment on your post moves to the top</li>
-          </ul>
-          <div>
-            <a (click)="hideDiamondInfo($event)" class="fc-muted">hide explainer</a>
-          </div>
+          from you.
         </div>
         <div class="d-flex justify-content-center pt-10px">
           <rating

--- a/src/app/feed/feed-post-icon-row/feed-post-icon-row.component.ts
+++ b/src/app/feed/feed-post-icon-row/feed-post-icon-row.component.ts
@@ -40,7 +40,7 @@ export class FeedPostIconRowComponent {
   static SingleClickDebounce = 300;
 
   // Threshold above which user must confirm before sending diamonds
-  static DiamondWarningThreshold = 3;
+  static DiamondWarningThreshold = 4;
 
   // Boolean for animation on whether a heart is clicked or not
   animateLike = false;
@@ -361,10 +361,6 @@ export class FeedPostIconRowComponent {
     event.stopPropagation();
     if (!this.globalVars.loggedInUser) {
       return this._preventNonLoggedInUserActions("diamond");
-    } else if (!this.globalVars.doesLoggedInUserHaveProfile()) {
-      this.globalVars.logEvent("alert : diamond : profile");
-      SharedDialogs.showCreateProfileToPerformActionDialog(this.router, "diamond");
-      return;
     } else if (this.globalVars.loggedInUser.PublicKeyBase58Check === this.postContent.PosterPublicKeyBase58Check) {
       this.globalVars._alertError("You cannot diamond your own post");
       return;
@@ -451,10 +447,10 @@ export class FeedPostIconRowComponent {
       SwalHelper.fire({
         target: this.globalVars.getTargetComponentSelector(),
         icon: "info",
-        title: `Sending ${this.diamondSelected} diamonds to ${this.postContent.ProfileEntryResponse?.Username}`,
+        title: `Sending ${this.diamondSelected} diamonds to @${this.postContent.ProfileEntryResponse?.Username}`,
         html: `Clicking confirm will send ${this.globalVars.getUSDForDiamond(
           this.diamondSelected
-        )} worth of your creator coin to @${this.postContent.ProfileEntryResponse?.Username}`,
+        )} to @${this.postContent.ProfileEntryResponse?.Username}`,
         showCancelButton: true,
         showConfirmButton: true,
         focusConfirm: true,

--- a/src/app/update-profile-page/update-profile/update-profile.component.html
+++ b/src/app/update-profile-page/update-profile/update-profile.component.html
@@ -102,46 +102,39 @@
             </div>
           </div>
 
-          <div class="mt-30px font-weight-bold">Founder Reward Percentage</div>
+          <div *ngIf="globalVars.loggedInUser.UsersWhoHODLYouCount !== 0">
+            <div class="mt-30px font-weight-bold">Founder Reward Percentage</div>
 
-          <div class="mt-10px">
-            <div class="d-flex align-items-center justify-content-start h-100">
-              <input
-                [(ngModel)]="founderRewardInput"
-                min="0"
-                max="100"
-                type="number"
-                class="form-control fs-15px lh-15px p-10px w-25 text-right"
-                [disabled]="globalVars.loggedInUser.UsersWhoHODLYouCount === 0"
-              />
-              <i
-                (click)="tooltip.toggle()"
-                class="fas fa-info-circle text-greyC fs-15px global__tooltip-icon ml-10px"
-                matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
-                [matTooltip]="founderRewardTooltip()"
-                #tooltip="matTooltip"
-              ></i>
+            <div class="mt-10px">
+              <div class="d-flex align-items-center justify-content-start h-100">
+                <input
+                  [(ngModel)]="founderRewardInput"
+                  min="0"
+                  max="100"
+                  type="number"
+                  class="form-control fs-15px lh-15px p-10px w-25 text-right"
+                  [disabled]="globalVars.loggedInUser.UsersWhoHODLYouCount === 0"
+                />
+                <i
+                  (click)="tooltip.toggle()"
+                  class="fas fa-info-circle text-greyC fs-15px global__tooltip-icon ml-10px"
+                  matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
+                  [matTooltip]="founderRewardTooltip()"
+                  #tooltip="matTooltip"
+                ></i>
+              </div>
+              <div *ngIf="this.globalVars.loggedInUser.UsersWhoHODLYouCount === 0" class="fc-muted font-italic fs-13px pt-5px">
+                * You must purchase your own coin before lowering your founder reward.
+              </div>
+              <div
+                *ngIf="profileUpdateErrors.founderRewardError"
+                [ngClass]="{ 'fc-red': profileUpdateErrors.founderRewardError }"
+                class="fs-13px font-italic pt-5px"
+              >
+                Please set a founder reward between 0-100.
+              </div>
             </div>
-            <div *ngIf="this.globalVars.loggedInUser.UsersWhoHODLYouCount === 0" class="fc-muted font-italic fs-13px pt-5px">
-              * You must purchase your own coin before lowering your founder reward.
-            </div>
-            <div
-              *ngIf="profileUpdateErrors.founderRewardError"
-              [ngClass]="{ 'fc-red': profileUpdateErrors.founderRewardError }"
-              class="fs-13px font-italic pt-5px"
-            >
-              Please set a founder reward between 0-100.
-            </div>
-          </div>
 
-          <div class="mt-30px font-weight-bold">Public Key</div>
-
-          <div class="mt-10px d-flex align-items-center update-profile__pub-key fc-muted fs-110px">
-            {{ globalVars.loggedInUser.PublicKeyBase58Check }}
-            <i
-              class="far fa-copy ml-15px update-profile__copy fc-default fa-lg"
-              (click)="globalVars._copyText(globalVars.loggedInUser.PublicKeyBase58Check)"
-            ></i>
           </div>
 
           <div class="w-100 my-30px">

--- a/src/app/update-profile-page/update-profile/update-profile.component.ts
+++ b/src/app/update-profile-page/update-profile/update-profile.component.ts
@@ -78,9 +78,9 @@ export class UpdateProfileComponent implements OnInit, OnChanges {
 
   founderRewardTooltip() {
     return (
-      "When someone purchases your coin, a percentage of each coin purchase " +
+      "When someone purchases your coin, a percentage of that " +
       "gets allocated to you as a founder reward.\n\n" +
-      "A value of 0% means that no new coins get allocated to you when someone buys, " +
+      "A value of 0% means you get no money when someone buys, " +
       "whereas a value of 100% means that nobody other than you can ever get coins because 100% of " +
       "every purchase will just go to you.\n\n" +
       "Setting this value too high will deter buyers from ever " +


### PR DESCRIPTION
Add support for CLOUT diamonds PLUS...

* Allow anon diamonds to be given. This means we don't require a profile
to be created prior to giving a diamond.

* Handle anon diamonds gracefully on the Diamonds tab by grouping the
anon amounts together into one row.

* Don't show founder reward until user has bought some of their coin.

* Don't ask for confirmation on $5 diamonds because it's annoying.

* Update copy in various places to support CLOUT diamonds and anon
diamonds.