### PR TITLE
Impoved dark theme

### DIFF
--- a/src/app/theme/themes/dark.scss
+++ b/src/app/theme/themes/dark.scss
@@ -1,24 +1,25 @@
 // Dark Theme
 // By: 
 .dark[app-theme] {
-    --background: #121212;
-    --text: #EFF3F8;
+    --background: #000000;
+    --text: #D8D8D9;
     --grey: #999;
-    --secondary: #202020;
-    --secalt: #111;
+    --secondary: #080808;
+    --secalt: #0f0f0f;
     --textalt: #eee;
     --norm: #eee;
-    --formbg: #111;
+    --formbg: #0f0f0f;
     --link: #4DA3FF;
     --hover: #72b6ff;
-    --border: #484848;
-    --mborder: #484848;
+    --border: #0e0e0e;
+    --mborder: #0e0e0e;
     --filter: invert(98%) sepia(1%) saturate(264%) hue-rotate(181deg) brightness(116%) contrast(100%);
     --unread: #1a293f;
-    --topbar: #2E2E2E;
+    --topbar: #15191D;
     --cblue: #0058F7;
-    --cred: #fe3537;
+    --cred: #db4760;
     --cgreen: #19B028;
     --button: #0058F7;
     --loading: #999;
 }
+


### PR DESCRIPTION
Background color and icon color improvement for dark theme.
Earlier font and icon color were quite choking to eyes

Before:

![Screenshot from 2021-08-13 16-32-35](https://user-images.githubusercontent.com/55331140/129349991-d4831d3a-48ad-4f2b-be73-0af99cbcf6e2.png)

After: 
![Screenshot from 2021-08-13 16-50-34](https://user-images.githubusercontent.com/55331140/129349999-8731d8f3-8082-4daf-9e2a-7be1af5e57c0.png)

PS: Unrelated to theme, but after the merge of nifty branch, I am seeing weird scroll bars on page 
I tested this in brave and firefox (screen size: 15`6 , 1366x768)