### PR TITLE
Share Post 

### DIFF
--- a/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.html
+++ b/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.html
@@ -15,7 +15,7 @@
       Link to Post
     </a>
     <a
-      *ngIf="navigator.share"
+      *ngIf="navigator.share !== undefined"
       class="dropdown-menu-item fs-12px d-block link--unstyled p-10px feed-post__dropdown-menu-item"
       (click)="sharePostUrl($event)"
       >

--- a/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.html
+++ b/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.html
@@ -15,6 +15,7 @@
       Link to Post
     </a>
     <a
+      *ngIf="navigator.share"
       class="dropdown-menu-item fs-12px d-block link--unstyled p-10px feed-post__dropdown-menu-item"
       (click)="sharePostUrl($event)"
       >

--- a/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.html
+++ b/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.html
@@ -15,6 +15,13 @@
       Link to Post
     </a>
     <a
+      class="dropdown-menu-item fs-12px d-block link--unstyled p-10px feed-post__dropdown-menu-item"
+      (click)="sharePostUrl($event)"
+      >
+      <i class="fas fa-share-square"></i>
+      Share Post
+    </a>
+    <a
       *ngIf="globalVars.loggedInUser.PublicKeyBase58Check === post.PosterPublicKeyBase58Check && !post.IsNFT && !post.ParentStakeID"
       class="dropdown-menu-item fs-12px d-block link--unstyled p-10px feed-post__dropdown-menu-item text-success"
       (click)="openMintNftModal($event)"

--- a/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.ts
+++ b/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.ts
@@ -196,7 +196,6 @@ export class FeedPostDropdownComponent {
 
     try {
       navigator.share({url: this._getPostUrl() });
-      console.log("Data was shared successfully");
     } catch (err) {
       console.error("Share failed:", err.message);
     }

--- a/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.ts
+++ b/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.ts
@@ -188,6 +188,20 @@ export class FeedPostDropdownComponent {
     this.globalVars._copyText(this._getPostUrl());
   }
 
+  sharePostUrl(event){
+    this.globalVars.logEvent("post : webapishare");
+    
+    // Prevent the post from navigating.
+    event.stopPropagation();
+
+    try {
+      navigator.share({url: this._getPostUrl() });
+      console.log("Data was shared successfully");
+    } catch (err) {
+      console.error("Share failed:", err.message);
+    }
+  }
+
   _getPostUrl() {
     const pathArray = ["/" + this.globalVars.RouteNames.POSTS, this.postContent.PostHashHex];
 


### PR DESCRIPTION
Adds a share post option in the post drop down menu using the built in [web share api](https://www.w3.org/TR/web-share/) .  Supported by Egde, Chrome and Safari

See screenshots:


in list:
![2021-08-14 (6)](https://user-images.githubusercontent.com/1112640/129449815-f0bb3031-285d-402e-a863-999d2f7e8444.png)

single post thread:
![2021-08-14 (4)](https://user-images.githubusercontent.com/1112640/129449818-70b7099e-f28d-4cff-b994-036b18d08b4c.png)

detail after click/touch a native prompt will be opened by the browser:
![2021-08-14 (5)](https://user-images.githubusercontent.com/1112640/129449817-e938bdb7-988f-4139-b3cc-dfcc4c0f7ec2.png)

mobile:
![localhost_4200_posts_e17f98384111c7aec62640e80e6918893269e91264e35c7a2db2d2afd351d64f_feedTab=Global(iPhone 6_7_8 Plus) (1)](https://user-images.githubusercontent.com/1112640/129449912-7509f5e6-778f-4e58-9b3c-2d3959049ca5.png)
