### PR TITLE
Update Content Security Policy for IPFS

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -51,7 +51,7 @@ header @html Content-Security-Policy "
     'unsafe-inline'
     https://fonts.googleapis.com
     https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css;
-  img-src 'self' data: i.imgur.com images.bitclout.com quickchart.io arweave.net *.arweave.net;
+  img-src 'self' data: i.imgur.com images.bitclout.com quickchart.io arweave.net *.arweave.net ipfs.io gateway.ipfs.io gateway.pinata.cloud *.mypinata.cloud;
   font-src 'self'
     https://fonts.googleapis.com
     https://fonts.gstatic.com


### PR DESCRIPTION
For an upcoming NFT project, I wish to host my image files using IPFS.  

This update enables images hosted on IPFS and via Pinata (https://www.pinata.cloud/) to be displayed on BitClout.com currently blocked by the Content Security Policy.

ipfs.io: default ipfs url
gateway.ipfs.io: default ipfs gateway url
gateway.pinata.cloud: default pinata ipfs gateway
*.mypinata.cloud: custom gateway urls enabled by pinata

List of IPFS gateways:
https://ipfs.github.io/public-gateway-checker/