### PR TITLE
fix: move hover bridge from before attribute on button to after attri…

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2484,25 +2484,27 @@ input {
     position: absolute;
     left: -4px;
     cursor: pointer;
-
-    // This creates an invisible, hoverable space for our pointer to use without losing hover focus
-    // Basically, a bridge between the diamond button and the diamond row
     &::before {
-      content: "."; opacity: 0;
-      display: block;
-      width: 80px;
-      // On desktop, move the diamond bar higher to prevent accidental clicking
-      @media (max-width: 991.98px) {
-        height: 10px;
-        top: -5px; left: -20px;
-      }
-      height: 30px;
-      position: absolute;
-      top: -25px; left: -20px;
+      display: none
     }
-
     // Contains box which contains all of the selectable diamond levels
     .reaction-box {
+      // This creates an invisible, hoverable space for our pointer to use without losing hover focus
+      // Basically, a bridge between the diamond button and the diamond row
+      &::after {
+        content: "."; opacity: 0;
+        display: block;
+        width: 340px;
+        // On desktop, move the diamond bar higher to prevent accidental clicking
+        @media (max-width: 991.98px) {
+          height: 10px;
+          top: 50px; left: 0px;
+        }
+        height: 30px;
+        position: absolute;
+        top: 50px; left: 0px;
+      }
+
       // Need to position box above top bar when explainer is triggered
       z-index: 30;
       position: absolute;


### PR DESCRIPTION
…bute on diamond box. Expand width of hover box so as to not lose focus when user moves mouse too far left or right

Before:
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/88362450/130090869-c87b4564-0560-4e16-916d-369d68386fae.gif)


After:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/88362450/130090780-fba73d9a-0c2a-4020-91db-ee8f32e77a1f.gif)


(Green background added for gif demonstration)