### PR TITLE
fix: inc warning threshold to 515

### DIFF
--- a/src/app/feed/feed-create-post/feed-create-post.component.ts
+++ b/src/app/feed/feed-create-post/feed-create-post.component.ts
@@ -13,7 +13,7 @@ import { environment } from "../../../environments/environment";
   styleUrls: ["./feed-create-post.component.sass"],
 })
 export class FeedCreatePostComponent implements OnInit {
-  static SHOW_POST_LENGTH_WARNING_THRESHOLD = 260; // show warning at 260 characters
+  static SHOW_POST_LENGTH_WARNING_THRESHOLD = 515; // show warning at 515 characters
 
   EmbedUrlParserService = EmbedUrlParserService;
 


### PR DESCRIPTION
Post length warning limit was still 260 and not increased after post length was increases to 560.

So set warning length to 515 now.

As per https://github.com/bitclout/cips/discussions/136#discussioncomment-1219223