### PR TITLE
Displays last accepted bid price on single-serial NFT feed posts

### DIFF
--- a/src/app/feed/feed-post/feed-post.component.html
+++ b/src/app/feed/feed-post/feed-post.component.html
@@ -487,6 +487,9 @@
               : "Unlockable Content"
           }}
         </span>
+        <div *ngIf="nftLastAcceptedBidAmountNanos">
+          <b>Last price: {{ globalVars.nanosToBitClout(nftLastAcceptedBidAmountNanos) }} $CLOUT</b>
+        </div>
       </div>
       <button
         class="btn btn-primary font-weight-bold br-8px fs-13px"

--- a/src/app/feed/feed-post/feed-post.component.ts
+++ b/src/app/feed/feed-post/feed-post.component.ts
@@ -95,6 +95,7 @@ export class FeedPostComponent implements OnInit {
   @Input() nftCollectionHighBid = 0;
   @Input() nftCollectionLowBid = 0;
   @Input() isForSaleOnly: boolean = false;
+  @Input() nftLastAcceptedBidAmountNanos: number;
 
   @Input() showNFTDetails = false;
   @Input() showExpandedNFTDetails = false;
@@ -194,6 +195,9 @@ export class FeedPostComponent implements OnInit {
         this.showPlaceABid = !!(this.availableSerialNumbers.length - this.myAvailableSerialNumbers.length);
         this.highBid = _.maxBy(this.availableSerialNumbers, "HighestBidAmountNanos")?.HighestBidAmountNanos || 0;
         this.lowBid = _.minBy(this.availableSerialNumbers, "HighestBidAmountNanos")?.HighestBidAmountNanos || 0;
+        if (this.nftEntryResponses.length === 1) {
+          this.nftLastAcceptedBidAmountNanos = this.nftEntryResponses[0].LastAcceptedBidAmountNanos;
+        }
       });
   }
 

--- a/src/app/feed/feed-post/feed-post.component.ts
+++ b/src/app/feed/feed-post/feed-post.component.ts
@@ -95,7 +95,7 @@ export class FeedPostComponent implements OnInit {
   @Input() nftCollectionHighBid = 0;
   @Input() nftCollectionLowBid = 0;
   @Input() isForSaleOnly: boolean = false;
-  @Input() nftLastAcceptedBidAmountNanos: number;
+  nftLastAcceptedBidAmountNanos: number;
 
   @Input() showNFTDetails = false;
   @Input() showExpandedNFTDetails = false;


### PR DESCRIPTION
Resale generally indicates demand, but right now it's difficult to distinguish an NFT that is being resold from one that has been passed over due to lack of interest.

This updates the feed post component to show the "last price" on _of 1_ NFTs.

<img src="https://user-images.githubusercontent.com/354227/132149286-6c11b240-46b7-490c-bc19-a9ce181b07db.jpg" width="360">
