### PR TITLE
Fix referral amount not shown on first load of homepage.

### DIFF
--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -857,6 +857,7 @@ export class GlobalVarsService {
       if (queryParams.r) {
         localStorage.setItem("referralCode", queryParams.r);
         this.router.navigate([], { queryParams: { r: undefined }, queryParamsHandling: "merge" });
+        this.getReferralUSDCents();
       }
     });
 


### PR DESCRIPTION
Currently when you load a referral link for the first time, the referral code is stripped and added to localStorage but the "referralUSDCents" is not set.  This causes the referral amount to not show up on the first load of the home page. This change makes it so that referralUSDCents is set after the referral code is stripped, fixing the issue.